### PR TITLE
Shingle rewriter: handle generated terms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,11 +122,11 @@
           		</plugin>
         	</plugins>
     </reporting>
+
 	<distributionManagement>
 		<repository>
-			<id>bintray-rene-maven</id>
-			<name>renekrie-maven-querqy</name>
-			<url>https://api.bintray.com/maven/renekrie/maven/querqy</url>
+			<id>bintray</id>
+			<url>https://bintray.com/lichtsprung/maven/querqy</url>
 		</repository>
 	</distributionManagement>
 </project>

--- a/querqy-core/src/main/java/querqy/rewrite/contrib/ShingleRewriter.java
+++ b/querqy-core/src/main/java/querqy/rewrite/contrib/ShingleRewriter.java
@@ -22,6 +22,15 @@ public class ShingleRewriter extends AbstractNodeVisitor<Node> implements QueryR
 
     Term previousTerm = null;
     List<Term> termsToAdd = null;
+    boolean acceptGeneratedTerms = false;
+
+    public ShingleRewriter(){
+        this(false);
+    }
+
+    public ShingleRewriter(boolean acceptGeneratedTerms) {
+        this.acceptGeneratedTerms = acceptGeneratedTerms;
+    }
 
     @Override
     public ExpandedQuery rewrite(ExpandedQuery query) {
@@ -51,7 +60,10 @@ public class ShingleRewriter extends AbstractNodeVisitor<Node> implements QueryR
 
     @Override
     public Node visit(Term term) {
-        if (previousTerm != null && eq(previousTerm.getField(), term.getField())) {
+        if (previousTerm != null
+                && eq(previousTerm.getField(), term.getField())
+                && (term.isGenerated() == acceptGeneratedTerms || !term.isGenerated())
+                && (previousTerm.isGenerated() == acceptGeneratedTerms || !previousTerm.isGenerated())) {
             CharSequence seq = new CompoundCharSequence(null, previousTerm, term);
             termsToAdd.add(buildShingle(previousTerm, seq));
             termsToAdd.add(buildShingle(term, seq));

--- a/querqy-core/src/main/java/querqy/rewrite/contrib/ShingleRewriterFactory.java
+++ b/querqy-core/src/main/java/querqy/rewrite/contrib/ShingleRewriterFactory.java
@@ -10,10 +10,15 @@ import java.util.Map;
  * Factory for {@link ShingleRewriter}
  */
 public class ShingleRewriterFactory implements RewriterFactory {
+    private boolean acceptGeneratedTerms;
+
+    public ShingleRewriterFactory(boolean acceptGeneratedTerms){
+        this.acceptGeneratedTerms = acceptGeneratedTerms;
+    }
 
     @Override
     public QueryRewriter createRewriter(ExpandedQuery input, Map<String, ?> context) {
-        return new ShingleRewriter();
+        return new ShingleRewriter(acceptGeneratedTerms);
     }
 
 }

--- a/querqy-core/src/main/java/querqy/rewrite/contrib/ShingleRewriterFactory.java
+++ b/querqy-core/src/main/java/querqy/rewrite/contrib/ShingleRewriterFactory.java
@@ -12,6 +12,10 @@ import java.util.Map;
 public class ShingleRewriterFactory implements RewriterFactory {
     private boolean acceptGeneratedTerms;
 
+    public ShingleRewriterFactory(){
+        this.acceptGeneratedTerms = false;
+    }
+
     public ShingleRewriterFactory(boolean acceptGeneratedTerms){
         this.acceptGeneratedTerms = acceptGeneratedTerms;
     }

--- a/querqy-solr/src/main/java/querqy/solr/ShingleRewriterFactory.java
+++ b/querqy-solr/src/main/java/querqy/solr/ShingleRewriterFactory.java
@@ -14,6 +14,8 @@ public class ShingleRewriterFactory implements RewriterFactoryAdapter {
 
     @Override
     public RewriterFactory createRewriterFactory(NamedList<?> args, ResourceLoader resourceLoader) throws IOException {
-        return new querqy.rewrite.contrib.ShingleRewriterFactory();
+        Boolean acceptGeneratedTerms = args.getBooleanArg("acceptGeneratedTerms");
+        boolean t = (acceptGeneratedTerms == null) ? false : acceptGeneratedTerms;
+        return new querqy.rewrite.contrib.ShingleRewriterFactory(t);
     }
 }

--- a/querqy-solr/src/test/resources/solr/collection1/conf/solrconfig-shingles-and-commonrules.xml
+++ b/querqy-solr/src/test/resources/solr/collection1/conf/solrconfig-shingles-and-commonrules.xml
@@ -47,6 +47,7 @@
 		<lst name="rewriteChain">
 		   <lst name="rewriter">
 		   		<str name="class">querqy.solr.ShingleRewriterFactory</str>
+		   		<str name="acceptGeneratedTerms">true</str>
 		   </lst>
            <lst name="rewriter">
                <str name="class">querqy.solr.SimpleCommonRulesRewriterFactory</str>


### PR DESCRIPTION
This commit lets the user configure how the ShingleRewriter should handle generated terms. It introduces a new configurable flag (acceptGeneratedTerms) that defines the ShingleRewriter behaviour. 
acceptGeneratedTerms = true allows generated terms in shingles, acceptGeneratedTerms = false lets the ShingleRewriter ignore them.
