### PR TITLE
Have Rules Rewriter add some debug info to the Solr response

### DIFF
--- a/querqy-core/src/main/java/querqy/rewrite/ContextAwareQueryRewriter.java
+++ b/querqy-core/src/main/java/querqy/rewrite/ContextAwareQueryRewriter.java
@@ -16,7 +16,12 @@ import querqy.model.ExpandedQuery;
  *
  */
 public interface ContextAwareQueryRewriter extends QueryRewriter {
-    
+
+    /**
+     * Name of the context key that acts as a flag to request debug information.
+     */
+    String CONTEXT_KEY_ISDEBUG = "querqy.qparser.isdebug";
+
     ExpandedQuery rewrite(ExpandedQuery query, Map<String, Object> context);
 
 }

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/CommonRulesRewriter.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/CommonRulesRewriter.java
@@ -3,6 +3,7 @@
  */
 package querqy.rewrite.commonrules;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -31,7 +32,9 @@ import querqy.rewrite.commonrules.model.InputBoundary.Type;
  *
  */
 public class CommonRulesRewriter extends AbstractNodeVisitor<Node> implements ContextAwareQueryRewriter {
-    
+
+    public static final String CONTEXT_KEY_RULESDEBUG = "querqy_rulesrewriter_actions";
+
     static final InputBoundary LEFT_BOUNDARY = new InputBoundary(Type.LEFT);
     static final InputBoundary RIGHT_BOUNDARY = new InputBoundary(Type.RIGHT);
 
@@ -67,7 +70,7 @@ public class CommonRulesRewriter extends AbstractNodeVisitor<Node> implements Co
          sequencesStack.add(new PositionSequence<Term>());
         
          super.visit((BooleanQuery) query.getUserQuery());
-        
+
          applySequence(sequencesStack.removeLast(), true);
          
       }
@@ -89,8 +92,15 @@ public class CommonRulesRewriter extends AbstractNodeVisitor<Node> implements Co
    protected void applySequence(PositionSequence<Term> sequence, boolean addBoundaries) {
        
        PositionSequence<InputSequenceElement> sequenceForLookUp = addBoundaries ? addBoundaries(sequence) : termSequenceToInputSequence(sequence);
-       
+
+       List<String> actionsDebugInfo = (List<String>) context.get(CONTEXT_KEY_RULESDEBUG);
+       if (actionsDebugInfo == null) {
+           actionsDebugInfo = new ArrayList<>();
+           context.put(CONTEXT_KEY_RULESDEBUG, actionsDebugInfo);
+       }
+
        for (Action action : rules.getRewriteActions(sequenceForLookUp)) {
+           actionsDebugInfo.add(action.toString());
            for (Instructions instructions : action.getInstructions()) {
               for (Instruction instruction : instructions) {
                  instruction.apply(sequence, action.getTermMatches(), action.getStartPosition(),

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/CommonRulesRewriter.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/CommonRulesRewriter.java
@@ -33,7 +33,7 @@ import querqy.rewrite.commonrules.model.InputBoundary.Type;
  */
 public class CommonRulesRewriter extends AbstractNodeVisitor<Node> implements ContextAwareQueryRewriter {
 
-    public static final String CONTEXT_KEY_RULESDEBUG = "querqy_rulesrewriter_actions";
+    public static final String CONTEXT_KEY_ACTIONSDEBUG = "querqy.commonrules.actionsdebug";
 
     static final InputBoundary LEFT_BOUNDARY = new InputBoundary(Type.LEFT);
     static final InputBoundary RIGHT_BOUNDARY = new InputBoundary(Type.RIGHT);
@@ -93,14 +93,18 @@ public class CommonRulesRewriter extends AbstractNodeVisitor<Node> implements Co
        
        PositionSequence<InputSequenceElement> sequenceForLookUp = addBoundaries ? addBoundaries(sequence) : termSequenceToInputSequence(sequence);
 
-       List<String> actionsDebugInfo = (List<String>) context.get(CONTEXT_KEY_RULESDEBUG);
-       if (actionsDebugInfo == null) {
+       boolean isDebug = Boolean.TRUE.equals(context.get(CONTEXT_KEY_ISDEBUG));
+       List<String> actionsDebugInfo = (List<String>) context.get(CONTEXT_KEY_ACTIONSDEBUG);
+       // prepare debug info context object if requested
+       if (isDebug && actionsDebugInfo == null) {
            actionsDebugInfo = new ArrayList<>();
-           context.put(CONTEXT_KEY_RULESDEBUG, actionsDebugInfo);
+           context.put(CONTEXT_KEY_ACTIONSDEBUG, actionsDebugInfo);
        }
 
        for (Action action : rules.getRewriteActions(sequenceForLookUp)) {
-           actionsDebugInfo.add(action.toString());
+           if (isDebug) {
+               actionsDebugInfo.add(action.toString());
+           }
            for (Instructions instructions : action.getInstructions()) {
               for (Instruction instruction : instructions) {
                  instruction.apply(sequence, action.getTermMatches(), action.getStartPosition(),

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/model/TermMatch.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/model/TermMatch.java
@@ -44,6 +44,15 @@ public class TermMatch {
     }
 
     @Override
+    public String toString() {
+        return "TermMatch{" +
+                "queryTerm=" + queryTerm +
+                ", isPrefix=" + isPrefix +
+                ", wildcardMatch=" + wildcardMatch +
+                '}';
+    }
+
+    @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;

--- a/querqy-core/src/test/java/querqy/rewrite/commonrules/AbstractCommonRulesTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/commonrules/AbstractCommonRulesTest.java
@@ -1,7 +1,7 @@
 package querqy.rewrite.commonrules;
 
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import querqy.model.ExpandedQuery;
@@ -10,7 +10,7 @@ import querqy.rewrite.commonrules.model.Term;
 
 public abstract class AbstractCommonRulesTest {
     
-   public final static Map<String, Object> EMPTY_CONTEXT = Collections.emptyMap();
+   public final static Map<String, Object> EMPTY_CONTEXT = new HashMap<>();
 
    protected ExpandedQuery makeQuery(String input) {
       return new ExpandedQuery(new WhiteSpaceQuerqyParser().parse(input));

--- a/querqy-core/src/test/java/querqy/rewrite/commonrules/model/BoostInstructionTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/commonrules/model/BoostInstructionTest.java
@@ -25,8 +25,6 @@ import querqy.rewrite.commonrules.model.BoostInstruction.BoostDirection;
 
 public class BoostInstructionTest extends AbstractCommonRulesTest {
     
-    final static Map<String, Object> EMPTY_CONTEXT = Collections.emptyMap();
-
     @Test
     public void testThatBoostQueriesAreMarkedAsGenerated() {
         

--- a/querqy-core/src/test/java/querqy/rewrite/commonrules/model/CommonRulesRewriterTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/commonrules/model/CommonRulesRewriterTest.java
@@ -1,5 +1,8 @@
 package querqy.rewrite.commonrules.model;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static querqy.QuerqyMatchers.bq;
 import static querqy.QuerqyMatchers.dmq;
@@ -7,6 +10,7 @@ import static querqy.QuerqyMatchers.term;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
@@ -18,8 +22,6 @@ import querqy.rewrite.commonrules.CommonRulesRewriter;
 
 public class CommonRulesRewriterTest extends AbstractCommonRulesTest {
 
-    final static Map<String, Object> EMPTY_CONTEXT = Collections.emptyMap();
-    
     @Test
     public void testInputBoundaryOnBothSides() {
         RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
@@ -242,5 +244,36 @@ public class CommonRulesRewriterTest extends AbstractCommonRulesTest {
                      ) 
                      
           ));    
+    }
+
+    @Test
+    public void testActionsAreLoggedInContext() {
+        RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
+        SynonymInstruction synInstructionA = new SynonymInstruction(Arrays.asList(mkTerm("aSynonym")));
+        SynonymInstruction synInstructionB = new SynonymInstruction(Arrays.asList(mkTerm("bSynonym")));
+        builder.addRule(new Input(Arrays.asList(mkTerm("a")), true, false), new Instructions(Arrays.asList((Instruction) synInstructionA)));
+        builder.addRule(new Input(Arrays.asList(mkTerm("b")), true, false), new Instructions(Arrays.asList((Instruction) synInstructionB)));
+        RulesCollection rules = builder.build();
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+
+        ExpandedQuery query = makeQuery("a b");
+        Map<String, Object> context = new HashMap<>();
+        Query rewritten = rewriter.rewrite(query, context).getUserQuery();
+
+        assertThat(rewritten,
+                bq(
+                        dmq(
+                                term("a", false),
+                                term("aSynonym", true)
+                        ),
+                        dmq(
+                                term("b", false)
+
+                        )
+                ));
+
+        assertThat(context.containsKey(CommonRulesRewriter.CONTEXT_KEY_RULESDEBUG), is(true));
+        assertThat(context.get(CommonRulesRewriter.CONTEXT_KEY_RULESDEBUG).toString(), containsString(synInstructionA.toString()));
+        assertThat(context.get(CommonRulesRewriter.CONTEXT_KEY_RULESDEBUG).toString(), not(containsString(synInstructionB.toString())));
     }
 }

--- a/querqy-core/src/test/java/querqy/rewrite/commonrules/model/CommonRulesRewriterTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/commonrules/model/CommonRulesRewriterTest.java
@@ -3,13 +3,13 @@ package querqy.rewrite.commonrules.model;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static querqy.QuerqyMatchers.bq;
 import static querqy.QuerqyMatchers.dmq;
 import static querqy.QuerqyMatchers.term;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -272,8 +272,14 @@ public class CommonRulesRewriterTest extends AbstractCommonRulesTest {
                         )
                 ));
 
-        assertThat(context.containsKey(CommonRulesRewriter.CONTEXT_KEY_RULESDEBUG), is(true));
-        assertThat(context.get(CommonRulesRewriter.CONTEXT_KEY_RULESDEBUG).toString(), containsString(synInstructionA.toString()));
-        assertThat(context.get(CommonRulesRewriter.CONTEXT_KEY_RULESDEBUG).toString(), not(containsString(synInstructionB.toString())));
+        assertThat(context.get(CommonRulesRewriter.CONTEXT_KEY_ACTIONSDEBUG), is(nullValue()));
+
+        context.put(CommonRulesRewriter.CONTEXT_KEY_ISDEBUG, true);
+        rewriter.rewrite(query, context).getUserQuery();
+
+        assertThat(context.containsKey(CommonRulesRewriter.CONTEXT_KEY_ACTIONSDEBUG), is(true));
+        assertThat(context.get(CommonRulesRewriter.CONTEXT_KEY_ACTIONSDEBUG).toString(), containsString(synInstructionA.toString()));
+        assertThat(context.get(CommonRulesRewriter.CONTEXT_KEY_ACTIONSDEBUG).toString(), not(containsString(synInstructionB.toString())));
     }
+
 }

--- a/querqy-core/src/test/java/querqy/rewrite/commonrules/model/DeleteInstructionTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/commonrules/model/DeleteInstructionTest.java
@@ -26,8 +26,6 @@ import querqy.rewrite.commonrules.model.Instructions;
 
 public class DeleteInstructionTest extends AbstractCommonRulesTest {
     
-    final static Map<String, Object> EMPTY_CONTEXT = Collections.emptyMap();
-
    @Test
    public void testThatNothingIsDeletedIfWeWouldEndUpWithAnEmptyQuery() {
 

--- a/querqy-core/src/test/java/querqy/rewrite/commonrules/model/FilterInstructionTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/commonrules/model/FilterInstructionTest.java
@@ -25,8 +25,6 @@ import static querqy.QuerqyMatchers.term;
  */
 public class FilterInstructionTest  extends AbstractCommonRulesTest {
 
-    final static Map<String, Object> EMPTY_CONTEXT = Collections.emptyMap();
-
     @Test
     public void testPurelyNegativeFilterQuery() {
 

--- a/querqy-for-lucene/pom.xml
+++ b/querqy-for-lucene/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <querqy.core.version>3.0.5</querqy.core.version>
+        <querqy.core.version>3.2.0-SNAPSHOT</querqy.core.version>
         <querqy.antlr.version>3.0.2</querqy.antlr.version>
         <lucene.version>6.2.0</lucene.version>
         <commons.io.version>2.1</commons.io.version>

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyDismaxQParser.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyDismaxQParser.java
@@ -44,6 +44,7 @@ import querqy.model.QuerqyQuery;
 import querqy.model.RawQuery;
 import querqy.model.Term;
 import querqy.parser.QuerqyParser;
+import querqy.rewrite.ContextAwareQueryRewriter;
 import querqy.rewrite.RewriteChain;
 
 /**
@@ -199,6 +200,8 @@ public class QuerqyDismaxQParser extends ExtendedDismaxQParser {
 
     protected final float qpfTie;
 
+    protected final boolean debugQuery;
+
     public QuerqyDismaxQParser(String qstr, SolrParams localParams, SolrParams params,
          SolrQueryRequest req, RewriteChain rewriteChain, QuerqyParser querqyParser, TermQueryCache termQueryCache)
          throws SyntaxError {
@@ -278,6 +281,8 @@ public class QuerqyDismaxQParser extends ExtendedDismaxQParser {
 
         qpfTie = solrParams.getFloat(QPF_TIE, config.getTieBreaker());
 
+        debugQuery = req.getParams().getBool(CommonParams.DEBUG_QUERY, false);
+
     }
    
    protected FieldBoostModel getFieldBoostModelFromParam(SolrParams solrParams) {
@@ -335,6 +340,9 @@ public class QuerqyDismaxQParser extends ExtendedDismaxQParser {
           expandedQuery = makeExpandedQuery();
           phraseFieldQuery = makePhraseFieldQueries(expandedQuery.getUserQuery());
           context = new HashMap<>();
+          if (debugQuery) {
+              context.put(ContextAwareQueryRewriter.CONTEXT_KEY_ISDEBUG, true);
+          }
           expandedQuery = rewriteChain.rewrite(expandedQuery, context);
          
           mainQuery = makeMainQuery(expandedQuery);

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyQueryComponent.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyQueryComponent.java
@@ -64,9 +64,9 @@ public class QuerqyQueryComponent extends QueryComponent {
 
                 if (rb.isDebugQuery()) {
                     @SuppressWarnings("unchecked")
-                    List<String> rulesDebugInfo = (List<String>) context.get(CommonRulesRewriter.CONTEXT_KEY_RULESDEBUG);
+                    List<String> rulesDebugInfo = (List<String>) context.get(CommonRulesRewriter.CONTEXT_KEY_ACTIONSDEBUG);
                     if (rulesDebugInfo != null) {
-                        rb.addDebugInfo(CommonRulesRewriter.CONTEXT_KEY_RULESDEBUG, rulesDebugInfo);
+                        rb.addDebugInfo(CommonRulesRewriter.CONTEXT_KEY_ACTIONSDEBUG, rulesDebugInfo);
                     }
                 }
 

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyQueryComponent.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyQueryComponent.java
@@ -13,6 +13,7 @@ import org.apache.solr.handler.component.QueryComponent;
 import org.apache.solr.handler.component.ResponseBuilder;
 import org.apache.solr.search.QParser;
 
+import querqy.rewrite.commonrules.CommonRulesRewriter;
 import querqy.rewrite.commonrules.model.DecorateInstruction;
 
 /**
@@ -60,7 +61,15 @@ public class QuerqyQueryComponent extends QueryComponent {
             
             Map<String, Object> context = ((QuerqyDismaxQParser) parser).getContext();
             if (context != null) {
-                
+
+                if (rb.isDebugQuery()) {
+                    @SuppressWarnings("unchecked")
+                    List<String> rulesDebugInfo = (List<String>) context.get(CommonRulesRewriter.CONTEXT_KEY_RULESDEBUG);
+                    if (rulesDebugInfo != null) {
+                        rb.addDebugInfo(CommonRulesRewriter.CONTEXT_KEY_RULESDEBUG, rulesDebugInfo);
+                    }
+                }
+
                 @SuppressWarnings("unchecked")
                 Set<Object> decorations = (Set<Object>) context.get(DecorateInstruction.CONTEXT_KEY);
                 if (decorations != null) {

--- a/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/DefaultQuerqyDismaxQParserWithCommonRulesTest.java
+++ b/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/DefaultQuerqyDismaxQParserWithCommonRulesTest.java
@@ -341,4 +341,25 @@ public class DefaultQuerqyDismaxQParserWithCommonRulesTest extends SolrTestCaseJ
         req.close();
     }
 
+    @Test
+    public void testSolrResponseContainsDebugInformationOfRulesRewriter() throws Exception {
+        String q = "a b";
+
+        String debugQueryRuleForA = "Action [instructions=[[FilterInstruction [filterQuery=RawQuery [queryString=f2:c]]]], " +
+                "terms=[TermMatch{queryTerm=*:a, isPrefix=false, wildcardMatch=null}], startPosition=0, endPosition=1]";
+
+        SolrQueryRequest requestWithDebugQueryEnabled = req("q", q,
+                DisMaxParams.QF, "f1 f2 f3",
+                "defType", "querqy",
+                "debugQuery", "on"
+        );
+
+        assertQ("Rules debug information not included in debug field of Solr response",
+                requestWithDebugQueryEnabled,
+                "//lst[@name='debug']/arr[@name='querqy.commonrules.actionsdebug']/str[text() = '" + debugQueryRuleForA + "']"
+        );
+
+        requestWithDebugQueryEnabled.close();
+    }
+
 }


### PR DESCRIPTION
Simply adds some info on the applied query rules to the Solr response. Not perfect, rather "good enough".
* Could use some more readable debug info syntax instead of Action.toString() (JSON?)
* A more Solr "idiomatic" way could be to implement QParser#addDebugInfo in QuerqyDismaxQParser but wasn't sure about the lifecycle here.
* Could be restricted to only add debug info to the Querqy context if it is a debug enabled request to save unnecessary .toStrings() in no-debug mode. 