### PR TITLE
Adding properties for querqy criterion selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,78 @@ Cache configuration (solrconfig.xml):
 </queryParser>          
 ~~~
 
+###Custom Changes
+In rewritter-chain in solr-config.xml add
+```
+         <!--
+          rules-map-type can be of 2 types :
+          1. default-rules-map, its the default if none is mentioned, then it will pick the default.
+          2. property-rules-map, this will also store properties of the rules that can be used under sort & filtering.
+          -->
+        <str name="rules-map-type">property-rules-map</str>
+
+          <!--
+          selection-strategy can be of 2 types :
+          1. default-selection-strategy, its the default if none is mentioned, it will do nothing and return all the actions and apply all of them.
+          2. select-only1-selection-stratedgy, this will apply functions like sort , filter on the actions and return the top 1 action;
+          -->
+        <str name="selection-strategy">select-only1-selection-stratedgy</str>
+
+        In url we need to pass
+        For No of Rules to apply:
+        rules.criteria.size=1
+
+        For Rules Sort
+        rules.criteria.sort=priority%20desc
+
+        For Filter:
+        rules.criteria.filter=active:false
+
+```
+
+
+####
+Sample Rules.txt
+
+```
+party food =>
+    SYNONYM: bird food
+    SYNONYM: cat food
+    DOWN(50): party food
+    property.priority: 2
+    property.active: true
+    property.id: 1
+
+bird food =>
+    SYNONYM: bird food
+    SYNONYM: cat food
+    DOWN(50): party food
+    property.createdBy: lucky sharma
+    property.priority: 10
+    property.active: true
+    property.id: 2
+
+food =>
+    SYNONYM: aves edible
+    SYNONYM: whale fodder
+    DOWN(50): party food
+    property.createdBy: lucky sharma
+    property.priority: 4
+    property.active: false
+    property.id: 3
+
+bird =>
+    SYNONYM: hallow
+    SYNONYM: lucky
+    DOWN(50): beaf
+    property.priority: 1
+    property.active: false
+    property.id: 4
+
+kinder* =>
+	SYNONYM: kinder $1
+	property.id: 5
+```
 
 
 ## License
@@ -660,6 +732,8 @@ Please base development on the branch for the corresponding Solr version. querqy
 Many thanks to [Galeria Kaufhof](https://github.com/Galeria-Kaufhof), [shopping24](https://github.com/shopping24/) and [inoio](https://github.com/inoio) for their support.
 
 [Querqy is built using Travis CI](https://travis-ci.org/renekrie/querqy).
+
+
 
 
 

--- a/querqy-core/pom.xml
+++ b/querqy-core/pom.xml
@@ -22,6 +22,7 @@
         <junit.version>4.11</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>1.10.19</mockito.version>
+        <lombok.version>1.18.2</lombok.version>
     </properties>
 
     <dependencies>
@@ -49,6 +50,17 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+        </dependency>
+
     </dependencies>
 
 
@@ -94,8 +106,8 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/querqy-core/src/main/java/querqy/Constants.java
+++ b/querqy-core/src/main/java/querqy/Constants.java
@@ -1,0 +1,18 @@
+package querqy;
+
+public final class Constants {
+
+  private Constants() {
+  }
+
+  public static final String RULES_MAP_TYPE = "rules-map-type";
+  public static final String PROPERTY_RULES_MAP = "property-rules-map";
+  public static final String DEFAULT_RULES_MAP = "default-rules-map";
+
+  public static final String SELECTION_STRATEDGY = "selection-strategy";
+  public static final String DEFAULT_SELECTION_STRATEDGY = "default-selection-stratedgy";
+  public static final String CUSTOM_SELECTION_STRATEDGY = "custom-selection-stratedgy";
+
+
+}
+ 

--- a/querqy-core/src/main/java/querqy/model/Criteria.java
+++ b/querqy-core/src/main/java/querqy/model/Criteria.java
@@ -1,0 +1,12 @@
+package querqy.model;
+
+import querqy.rewrite.commonrules.model.Action;
+
+import java.util.List;
+
+public interface Criteria {
+
+  boolean isValid(Action action);
+
+  List<Action> apply(List<Action> actions);
+}

--- a/querqy-core/src/main/java/querqy/model/Criterion.java
+++ b/querqy-core/src/main/java/querqy/model/Criterion.java
@@ -1,0 +1,21 @@
+package querqy.model;
+
+import java.util.Collection;
+import java.util.LinkedList;
+
+public class Criterion extends LinkedList<Criteria> {
+
+  /**
+   *
+   */
+  private static final long serialVersionUID = 1L;
+
+  public Criterion() {
+    super();
+  }
+
+  public Criterion(Collection<Criteria> criterion) {
+    super(criterion);
+  }
+
+}

--- a/querqy-core/src/main/java/querqy/model/ExpandedQuery.java
+++ b/querqy-core/src/main/java/querqy/model/ExpandedQuery.java
@@ -1,73 +1,94 @@
 /**
- * 
+ *
  */
 package querqy.model;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
+import java.util.List;
 
 /**
- *
- * 
  * @author René Kriegler, @renekrie
- * 
- *         Note: this class does not synchronize access to filterQueries and
- *         boostQueries.
- *
+ * <p>
+ * Note: this class does not synchronize access to filterQueries and
+ * boostQueries.
  */
 public class ExpandedQuery {
 
-   private QuerqyQuery<?> userQuery;
-   protected Collection<QuerqyQuery<?>> filterQueries;
-   protected Collection<BoostQuery> boostUpQueries;
-   protected Collection<BoostQuery> boostDownQueries;
+    private QuerqyQuery<?> userQuery;
+    protected Collection<QuerqyQuery<?>> filterQueries;
+    protected Collection<BoostQuery> boostUpQueries;
+    protected Collection<BoostQuery> boostDownQueries;
+    protected Criterion criterion;
+    private List<String> appliedRuleIdList;
 
-   public ExpandedQuery(QuerqyQuery<?> userQuery) {
-      setUserQuery(userQuery);
-   }
+    public ExpandedQuery(QuerqyQuery<?> userQuery) {
+        setUserQuery(userQuery);
+        criterion = new Criterion();
+        appliedRuleIdList = new ArrayList<>();
+    }
 
-   public QuerqyQuery<?> getUserQuery() {
-      return userQuery;
-   }
+    public QuerqyQuery<?> getUserQuery() {
+        return userQuery;
+    }
 
-   public final void setUserQuery(QuerqyQuery<?> userQuery) {
-      if (userQuery == null) {
-         throw new IllegalArgumentException("userQuery required");
-      }
-      this.userQuery = userQuery;
-   }
+    public final void setUserQuery(QuerqyQuery<?> userQuery) {
+        if (userQuery == null) {
+            throw new IllegalArgumentException("userQuery required");
+        }
+        this.userQuery = userQuery;
+    }
 
-   public Collection<QuerqyQuery<?>> getFilterQueries() {
-      return filterQueries;
-   }
+    public Collection<QuerqyQuery<?>> getFilterQueries() {
+        return filterQueries;
+    }
 
-   public void addFilterQuery(QuerqyQuery<?> filterQuery) {
-      if (filterQueries == null) {
-         filterQueries = new LinkedList<>();
-      }
-      filterQueries.add(filterQuery);
-   }
+    public void addFilterQuery(QuerqyQuery<?> filterQuery) {
+        if (filterQueries == null) {
+            filterQueries = new LinkedList<>();
+        }
+        filterQueries.add(filterQuery);
+    }
 
-   public Collection<BoostQuery> getBoostUpQueries() {
-      return boostUpQueries;
-   }
+    public Collection<BoostQuery> getBoostUpQueries() {
+        return boostUpQueries;
+    }
 
-   public void addBoostUpQuery(BoostQuery boostUpQuery) {
-      if (boostUpQueries == null) {
-         boostUpQueries = new LinkedList<>();
-      }
-      boostUpQueries.add(boostUpQuery);
-   }
+    public void addBoostUpQuery(BoostQuery boostUpQuery) {
+        if (boostUpQueries == null) {
+            boostUpQueries = new LinkedList<>();
+        }
+        boostUpQueries.add(boostUpQuery);
+    }
 
-   public Collection<BoostQuery> getBoostDownQueries() {
-      return boostDownQueries;
-   }
+    public Collection<BoostQuery> getBoostDownQueries() {
+        return boostDownQueries;
+    }
 
-   public void addBoostDownQuery(BoostQuery boostDownQuery) {
-      if (boostDownQueries == null) {
-         boostDownQueries = new LinkedList<>();
-      }
-      boostDownQueries.add(boostDownQuery);
-   }
+    public void addBoostDownQuery(BoostQuery boostDownQuery) {
+        if (boostDownQueries == null) {
+            boostDownQueries = new LinkedList<>();
+        }
+        boostDownQueries.add(boostDownQuery);
+    }
+
+    public void addCrieteria(Criteria value) {
+        if (value != null) {
+            criterion.add(value);
+        }
+    }
+
+    public Criterion getCriterion() {
+        return criterion;
+    }
+
+    public String getAppliedRuleIds() {
+        return appliedRuleIdList.toString();
+    }
+
+    public void addAppliedRuleId(String id) {
+        appliedRuleIdList.add(id);
+    }
 
 }

--- a/querqy-core/src/main/java/querqy/model/FilterCriteria.java
+++ b/querqy-core/src/main/java/querqy/model/FilterCriteria.java
@@ -1,0 +1,37 @@
+package querqy.model;
+
+import lombok.AllArgsConstructor;
+import org.apache.commons.collections4.CollectionUtils;
+import querqy.rewrite.commonrules.model.Action;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@AllArgsConstructor
+public class FilterCriteria implements Criteria {
+
+  String field;
+  String value;
+
+  @Override
+  public boolean isValid(Action action) {
+    if (CollectionUtils.isEmpty(action.getProperties())) {
+      return false;
+    }
+    return action.getProperties().get(0).getPropertyMap().getOrDefault(field, "").equals(value);
+  }
+
+  @Override
+  public List<Action> apply(List<Action> actions) {
+    return actions.parallelStream().filter(this::isValid).collect(Collectors.toList());
+  }
+
+  @Override
+  public String toString() {
+    return "FilterCriteria{" +
+        "field='" + field + '\'' +
+        ", value='" + value + '\'' +
+        '}';
+  }
+}
+

--- a/querqy-core/src/main/java/querqy/model/SelectionCriteria.java
+++ b/querqy-core/src/main/java/querqy/model/SelectionCriteria.java
@@ -1,0 +1,33 @@
+package querqy.model;
+
+import lombok.AllArgsConstructor;
+import querqy.rewrite.commonrules.model.Action;
+
+import java.util.List;
+
+@AllArgsConstructor
+public class SelectionCriteria implements Criteria {
+
+  int size;
+
+  @Override
+  public boolean isValid(Action action) {
+    return true;
+  }
+
+  @Override
+  public List<Action> apply(List<Action> actions) {
+    if (actions.size() > size) {
+      return actions.subList(0, size);
+    } else {
+      return actions;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "SelectionCriteria{" +
+        "size=" + size +
+        '}';
+  }
+}

--- a/querqy-core/src/main/java/querqy/model/SortCriteria.java
+++ b/querqy-core/src/main/java/querqy/model/SortCriteria.java
@@ -1,0 +1,63 @@
+package querqy.model;
+
+import lombok.AllArgsConstructor;
+import org.apache.commons.collections4.CollectionUtils;
+import querqy.rewrite.commonrules.model.Action;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+@AllArgsConstructor
+public class SortCriteria implements Criteria {
+
+  private String field;
+  private String type;
+
+  @Override
+  public List<Action> apply(List<Action> actions) {
+    Collections.sort(actions, new Comparator<Action>() {
+      @Override
+      public int compare(Action o1, Action o2) {
+
+        if (!(CollectionUtils.isNotEmpty(o1.getProperties())
+            && CollectionUtils.isNotEmpty(o2.getProperties())
+            && o1.getProperties().get(0) != null
+            && o2.getProperties().get(0) != null
+            && o1.getProperties().get(0).getPropertyMap() != null
+            && o2.getProperties().get(0).getPropertyMap() != null)) {
+          return 0;
+        }
+        String o1Value = o1.getProperties().get(0).getPropertyMap().getOrDefault(field, "");
+        String o2Value = o2.getProperties().get(0).getPropertyMap().getOrDefault(field, "");
+
+        if (type.equals("asc")) {
+          return o1Value.compareTo(o2Value);
+        } else if (type.equals("desc")) {
+          return o2Value.compareTo(o1Value);
+        }
+        return 0;
+      }
+    });
+    return actions;
+  }
+
+  @Override
+  public boolean isValid(Action action) {
+
+    return (CollectionUtils.isNotEmpty(action.getProperties())
+        && action.getProperties().get(0) != null
+        && action.getProperties().get(0).getPropertyMap() != null
+        && action.getProperties().get(0).getPropertyMap().containsKey(field));
+  }
+
+  @Override
+  public String toString() {
+    return "SortCriteria{" +
+        "field='" + field + '\'' +
+        ", type='" + type + '\'' +
+        '}';
+  }
+}
+
+

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/LineParser.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/LineParser.java
@@ -3,6 +3,7 @@
  */
 package querqy.rewrite.commonrules;
 
+import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -35,7 +36,8 @@ public class LineParser {
     public static final String INSTR_DELETE = "delete";
     public static final String INSTR_FILTER = "filter";
     public static final String INSTR_SYNONYM = "synonym";
-    
+	public static final String PROPERTY = "property";
+
     static final char RAWQUERY = '*';
 	
 	public static Object parse(String line, Input previousInput, QuerqyParserFactory querqyParserFactory) {
@@ -163,6 +165,10 @@ public class LineParser {
 		if (lcLine.startsWith(INSTR_DECORATE)) {
 		    return parseDecorateInstruction(line);
 		}
+
+        if(lcLine.startsWith(PROPERTY)) {
+            return parseProperty(line);
+        }
 		
 		return new ValidationError("Cannot parse line: " + line);
 		
@@ -369,5 +375,24 @@ public class LineParser {
 		return result;
 	
 	}
+
+    public static Object parseProperty(String  line) {
+
+        if (line.length() == PROPERTY.length()) {
+            return new ValidationError(PROPERTY + " requires a value");
+        }
+
+        String propValue = line.substring(PROPERTY.length()).trim();
+        if (propValue.charAt(0) != '.') {
+            return new ValidationError("Cannot parse line, '.' expetcted in property to get name " + line);
+        }
+
+        String key = propValue.substring(1, propValue.indexOf(":")).trim();
+        String val = propValue.substring(propValue.indexOf(":")).trim();
+        val = val.substring(1).trim();
+
+        return new AbstractMap.SimpleEntry<String, String>(key, val);
+    }
+
 
 }

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/SimpleCommonRulesRewriterFactory.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/SimpleCommonRulesRewriterFactory.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package querqy.rewrite.commonrules;
 
@@ -18,23 +18,24 @@ import querqy.rewrite.commonrules.model.RulesCollection;
 
 /**
  * @author René Kriegler, @renekrie
- *
  */
 public class SimpleCommonRulesRewriterFactory implements RewriterFactory {
 
     final RulesCollection rules;
+    final String ruleSelectionStratedgy;
 
     /**
-     * 
      * @param reader
      * @param querqyParserFactory
      * @param ignoreCase
      * @throws IOException
      */
     public SimpleCommonRulesRewriterFactory(final Reader reader, final QuerqyParserFactory querqyParserFactory,
-                                            final boolean ignoreCase) throws IOException {
+                                            final boolean ignoreCase, String type, String ruleSelectionStratedgy)
+            throws IOException {
         try {
-            rules = new SimpleCommonRulesParser(reader, querqyParserFactory, ignoreCase).parse();
+            this.ruleSelectionStratedgy = ruleSelectionStratedgy;
+            rules = new SimpleCommonRulesParser(reader, querqyParserFactory, ignoreCase, type).parse();
         } catch (final RuleParseException e) {
             throw new IOException(e);
         } finally {
@@ -48,21 +49,21 @@ public class SimpleCommonRulesRewriterFactory implements RewriterFactory {
 
     /*
      * (non-Javadoc)
-     *     
+     *
      * @see
      * querqy.rewrite.RewriterFactory#createRewriter(querqy.model.ExpandedQuery,
      * java.util.Map)
      */
     @Override
     public QueryRewriter createRewriter(final ExpandedQuery input, final Map<String, ?> context) {
-        return new CommonRulesRewriter(rules);
+        return new CommonRulesRewriter(rules, ruleSelectionStratedgy);
     }
 
     @Override
     public Set<Term> getGenerableTerms() {
         // REVISIT: return Iterator? Limit number of results?
         final Set<Term> result = new HashSet<Term>();
-        for (final Instruction instruction: rules.getInstructions()) {
+        for (final Instruction instruction : rules.getInstructions()) {
             result.addAll(instruction.getGenerableTerms());
         }
         return result;

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/model/Action.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/model/Action.java
@@ -4,6 +4,7 @@
 package querqy.rewrite.commonrules.model;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * An Action represents all Instructions triggered for specific input positions.
@@ -16,17 +17,25 @@ import java.util.List;
  */
 public class Action {
 
-   final List<Instructions> instructions;
+   final List<Properties> properties;
    final TermMatches termMatches;
    final int startPosition;
    final int endPosition; // exclusive
 
    public Action(List<Instructions> instructions, TermMatches termMatches, int startPosition, int endPosition) {
-      this.instructions = instructions;
+      this.properties = instructionsToPropertiesMap(instructions);
       this.termMatches = termMatches;
       this.startPosition = startPosition;
       this.endPosition = endPosition;
    }
+
+   public Action(List<Properties> properties, TermMatches termMatches, int startPosition, int endPosition, boolean onlyProperty) {
+      this.properties = properties;
+      this.termMatches = termMatches;
+      this.startPosition = startPosition;
+      this.endPosition = endPosition;
+   }
+
 
    @Override
    public int hashCode() {
@@ -34,7 +43,7 @@ public class Action {
       int result = 1;
       result = prime * result + endPosition;
       result = prime * result
-            + ((instructions == null) ? 0 : instructions.hashCode());
+            + ((properties == null) ? 0 : properties.hashCode());
       result = prime * result + startPosition;
       result = prime * result + ((termMatches == null) ? 0 : termMatches.hashCode());
       return result;
@@ -51,10 +60,10 @@ public class Action {
       Action other = (Action) obj;
       if (endPosition != other.endPosition)
          return false;
-      if (instructions == null) {
-         if (other.instructions != null)
+      if (properties == null) {
+         if (other.properties != null)
             return false;
-      } else if (!instructions.equals(other.instructions))
+      } else if (!properties.equals(other.properties))
          return false;
       if (startPosition != other.startPosition)
          return false;
@@ -68,13 +77,17 @@ public class Action {
 
    @Override
    public String toString() {
-      return "Action [instructions=" + instructions + ", terms=" + termMatches
+      return "Action [properties=" + properties + ", terms=" + termMatches
             + ", startPosition=" + startPosition + ", endPosition="
             + endPosition + "]";
    }
 
    public List<Instructions> getInstructions() {
-      return instructions;
+      return properties.stream().map(property->property.getInstructions()).collect(Collectors.toList());
+   }
+
+   public List<Properties> getProperties() {
+      return properties;
    }
 
    public TermMatches getTermMatches() {
@@ -87,6 +100,13 @@ public class Action {
 
    public int getEndPosition() {
       return endPosition;
+   }
+
+   private static List<Properties> instructionsToPropertiesMap(List<Instructions> instructionsList) {
+      return
+              instructionsList.stream().
+                      map(instructions-> new Properties(instructions)).
+                      collect(Collectors.toList());
    }
 
 }

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/model/CustomSelectionStratedgy.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/model/CustomSelectionStratedgy.java
@@ -1,0 +1,59 @@
+package querqy.rewrite.commonrules.model;
+
+import org.apache.commons.collections4.CollectionUtils;
+import querqy.model.Criteria;
+import querqy.model.Criterion;
+import querqy.model.SelectionCriteria;
+import querqy.model.SortCriteria;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CustomSelectionStratedgy implements SelectionStratedgy {
+
+  /**
+   * for endeca the selection involves the top first action after sort and filters
+   */
+  @Override
+  public List<Action> selectActions(List<Action> actions, Criterion criterion) {
+    if (CollectionUtils.isEmpty(actions) || CollectionUtils.isEmpty(criterion)) {
+      return actions;
+    }
+
+    List<Action> validActions = actions.parallelStream()
+        .filter(action -> isValidAction(criterion, action))
+        .collect(Collectors.toList());
+
+    Criteria selectionCriteria = null;
+    Criteria sortCriteria = null;
+
+    for (Criteria criteria : criterion) {
+      if (criteria instanceof SelectionCriteria) {
+        selectionCriteria = criteria;
+      } else if (criteria instanceof SortCriteria) {
+        sortCriteria = criteria;
+      }
+    }
+
+    List<Action> sortedAction = validActions;
+    if (sortCriteria != null) {
+      sortedAction = sortCriteria.apply(validActions);
+    }
+    if (selectionCriteria != null) {
+      return selectionCriteria.apply(sortedAction);
+    }
+    return sortedAction;
+//
+//    List<Action> sortedActions = criterion.parallelStream()
+//        .filter(criteria -> criteria instanceof SortCriteria)
+//        .map(criteria -> criteria.apply(validActions))
+//        .collect(Collectors.toList()).parallelStream()
+//        .flatMap(List::stream)
+//        .collect(Collectors.toList());
+
+  }
+
+  private static boolean isValidAction(Criterion criterion, Action action) {
+    return criterion.parallelStream().filter(criteria -> criteria.isValid(action)).count() > 0;
+  }
+}

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/model/DefaultSelectionStratedgy.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/model/DefaultSelectionStratedgy.java
@@ -1,0 +1,15 @@
+package querqy.rewrite.commonrules.model;
+
+import querqy.model.Criterion;
+
+import java.util.List;
+
+public class DefaultSelectionStratedgy implements SelectionStratedgy {
+
+
+  @Override
+  public List<Action> selectActions(List<Action> actions,
+                                    Criterion criterion) {
+    return actions;
+  }
+}

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/model/Properties.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/model/Properties.java
@@ -1,0 +1,20 @@
+package querqy.rewrite.commonrules.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Properties {
+  private Instructions instructions;
+  private Map<String, String> propertyMap;
+
+  public Properties(Instructions instructions) {
+    this.instructions = instructions;
+  }
+
+}

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/model/RulesCollectionBuilder.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/model/RulesCollectionBuilder.java
@@ -2,7 +2,7 @@ package querqy.rewrite.commonrules.model;
 
 public interface RulesCollectionBuilder {
 
-    public abstract void addRule(Input input, Instructions instructions);
+    public abstract void addRule(Input input, Properties properties);
 
     public abstract RulesCollection build();
 

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/model/SelectionStratedgy.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/model/SelectionStratedgy.java
@@ -1,0 +1,9 @@
+package querqy.rewrite.commonrules.model;
+
+import querqy.model.Criterion;
+
+import java.util.List;
+
+public interface SelectionStratedgy {
+  public List<Action> selectActions(List<Action> actions, Criterion criterion);
+}

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/model/SelectionStratedgyFactory.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/model/SelectionStratedgyFactory.java
@@ -1,0 +1,28 @@
+package querqy.rewrite.commonrules.model;
+
+
+import querqy.Constants;
+
+public class SelectionStratedgyFactory {
+
+  private static SelectionStratedgyFactory ourInstance = new SelectionStratedgyFactory();
+
+  public static SelectionStratedgyFactory getInstance() {
+    return ourInstance;
+  }
+
+  private SelectionStratedgyFactory() {
+  }
+
+  public SelectionStratedgy getSelectionStratedgy(String type) {
+    switch (type) {
+      case Constants
+          .DEFAULT_SELECTION_STRATEDGY:
+        return new DefaultSelectionStratedgy();
+      case Constants.CUSTOM_SELECTION_STRATEDGY:
+        return new CustomSelectionStratedgy();
+      default:
+        return new DefaultSelectionStratedgy();
+    }
+  }
+}

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/model/SortProperty.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/model/SortProperty.java
@@ -1,0 +1,40 @@
+package querqy.rewrite.commonrules.model;
+
+import lombok.Data;
+
+@Data
+public class SortProperty {
+
+  private String propertyName;
+  private boolean asc;
+
+  public SortProperty(String propertyName, boolean asc) {
+    this.propertyName = propertyName;
+    this.asc = asc;
+  }
+
+  public SortProperty(String sortPropertyStr) {
+    if (sortPropertyStr == null || !sortPropertyStr.contains(" ")) {
+      throw new IllegalArgumentException("sortPropertyStr must not be null");
+    }
+
+    String[] property = sortPropertyStr.split("\\s+");
+    if (property.length < 2) {
+      throw new IllegalArgumentException("sortPropertyStr must contain the type asc or desc");
+    }
+    propertyName = property[0];
+    String propertyOrder = property[1].toLowerCase();
+
+    switch (propertyOrder) {
+      case "asc":
+        this.asc = true;
+        break;
+      case "desc":
+        this.asc = false;
+        break;
+      default:
+        throw new IllegalArgumentException("sortPropertyStr must contain the type asc or desc");
+    }
+  }
+
+}

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/model/TrieMapRulesPropertiesCollection.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/model/TrieMapRulesPropertiesCollection.java
@@ -1,0 +1,253 @@
+/**
+ *
+ */
+package querqy.rewrite.commonrules.model;
+
+import querqy.CompoundCharSequence;
+import querqy.model.InputSequenceElement;
+import querqy.model.Term;
+import querqy.trie.State;
+import querqy.trie.States;
+import querqy.trie.TrieMap;
+
+import java.util.*;
+
+/**
+ * @author René Kriegler, @renekrie
+ */
+public class TrieMapRulesPropertiesCollection implements RulesCollection {
+
+  public static final String BOUNDARY_WORD = "\u0002";
+
+  final TrieMap<List<Properties>> trieMap;
+  final boolean ignoreCase;
+
+  public TrieMapRulesPropertiesCollection(TrieMap<List<Properties>> trieMap, boolean ignoreCase) {
+    if (trieMap == null) {
+      throw new IllegalArgumentException("trieMap must not be null");
+    }
+    this.trieMap = trieMap;
+    this.ignoreCase = ignoreCase;
+  }
+
+  /* (non-Javadoc)
+   * @see querqy.rewrite.commonrules.model.RulesCollection#getRewriteActions(querqy.rewrite.commonrules.model.PositionSequence)
+   */
+  @Override
+  public List<Action> getRewriteActions(final PositionSequence<InputSequenceElement> sequence) {
+    final List<Action> result = new ArrayList<>();
+    if (sequence.isEmpty()) {
+      return result;
+    }
+
+    // We have a list of terms (resulting from DisMax alternatives) per
+    // position. We now find all the combinations of terms in different
+    // positions and look them up as rules input in the dictionary
+    // LinkedList<List<Term>> positions = sequence.getPositions();
+    if (sequence.size() == 1) {
+      for (final Term term : new ClassFilter<>(sequence.getFirst(), Term.class)) {
+
+        final States<List<Properties>> states = trieMap
+            .get(term.toCharSequenceWithField(ignoreCase));
+
+        final State<List<Properties>> stateExactMatch = states.getStateForCompleteSequence();
+        if (stateExactMatch.isFinal() && stateExactMatch.value != null) {
+          result.add(
+              new Action(stateExactMatch.value, new TermMatches(new TermMatch(term)), 0, 1, true));
+        }
+
+        final List<State<List<Properties>>> statesForPrefixes = states.getPrefixes();
+        if (statesForPrefixes != null) {
+          for (final State<List<Properties>> stateForPrefix : statesForPrefixes) {
+
+            if (stateForPrefix.isFinal() && stateForPrefix.value != null) {
+              result.add(
+                  new Action(stateForPrefix.value,
+                      new TermMatches(
+                          new TermMatch(term,
+                              true,
+                              term.subSequence(stateForPrefix.index + 1, term.length()))),
+                      0, 1, true));
+            }
+          }
+        }
+
+      }
+    } else {
+
+      List<Prefix<List<Properties>>> prefixes = new LinkedList<>();
+      List<Prefix<List<Properties>>> newPrefixes = new LinkedList<>();
+
+      int pos = 0;
+
+      for (final List<InputSequenceElement> position : sequence) {
+
+        boolean anyTermAtPosition = false;
+
+        for (final InputSequenceElement element : position) {
+
+          final boolean isTerm = element instanceof Term;
+          anyTermAtPosition |= isTerm;
+
+          final CharSequence charSequenceForLookup;
+          if (isTerm) {
+            charSequenceForLookup = ((Term) element).toCharSequenceWithField(ignoreCase);
+          } else if (element instanceof InputBoundary) {
+            charSequenceForLookup = BOUNDARY_WORD;
+          } else {
+            throw new IllegalArgumentException(
+                "Cannot handle type of element in sequence " + element);
+          }
+
+          // combine term with prefixes (= sequences of terms) that brought us here
+          for (final Prefix<List<Properties>> prefix : prefixes) {
+
+            final States<List<Properties>> states = trieMap.get(
+                new CompoundCharSequence(null, " ", charSequenceForLookup), prefix.stateInfo);
+
+            final int ofs = isTerm ? 1 : 0;
+
+            // exact matches
+            final State<List<Properties>> stateExactMatch = states.getStateForCompleteSequence();
+            if (stateExactMatch.isKnown()) {
+              if (stateExactMatch.isFinal()) {
+                final TermMatches matches = new TermMatches(prefix.matches);
+                if (isTerm) {
+                  matches.add(new TermMatch((Term) element));
+                }
+                result.add(new Action(stateExactMatch.value, matches, pos - matches.size() + ofs,
+                    pos + ofs, true));
+              }
+              final Prefix<List<Properties>> newPrefix = new Prefix<List<Properties>>(prefix,
+                  stateExactMatch);
+              if (isTerm) {
+                newPrefix.addTerm(new TermMatch((Term) element));
+              }
+              newPrefixes.add(newPrefix);
+
+            }
+
+            // matches for prefixes (= beginnings of terms)
+            final List<State<List<Properties>>> statesForPrefixes = states.getPrefixes();
+            if (statesForPrefixes != null) {
+              for (final State<List<Properties>> stateForPrefix : statesForPrefixes) {
+
+                if (stateForPrefix.isFinal() && stateForPrefix.value != null) {
+                  final TermMatches matches = new TermMatches(prefix.matches);
+                  if (isTerm) {
+                    final Term term = (Term) element;
+                    matches.add(
+                        new TermMatch(term,
+                            true,
+                            term.subSequence(stateForPrefix.index + 1, term.length())));
+                  }
+
+                  result.add(new Action(stateForPrefix.value, matches, pos - matches.size() + ofs,
+                      pos + ofs, true));
+                }
+
+                // TODO: continue with next match after prefix match
+              }
+            }
+          }
+
+          // now see whether the term matches on its own...
+          final States<List<Properties>> states = trieMap.get(charSequenceForLookup);
+
+          final State<List<Properties>> stateExactMatch = states.getStateForCompleteSequence();
+          if (stateExactMatch.isKnown()) {
+            if (stateExactMatch.isFinal()) {
+              // we do not let match the boundary on its own:
+              if (isTerm) {
+                result.add(new Action(stateExactMatch.value,
+                    new TermMatches(new TermMatch((Term) element)), pos, pos + 1, true));
+              }
+            }
+            // ... and save it as a prefix to the following term
+            final Prefix<List<Properties>> newPrefix = isTerm
+                ? new Prefix<>(new TermMatch((Term) element), stateExactMatch)
+                : new Prefix<>(stateExactMatch);
+            newPrefixes.add(new Prefix<>(newPrefix, stateExactMatch));
+          }
+
+          final List<State<List<Properties>>> statesForPrefixes = states.getPrefixes();
+          if (statesForPrefixes != null) {
+            for (final State<List<Properties>> stateForPrefix : statesForPrefixes) {
+              if (stateForPrefix.isFinal() && stateForPrefix.value != null) {
+                if (isTerm) {
+                  final Term term = (Term) element;
+                  result.add(new Action(stateForPrefix.value, new TermMatches(
+                      new TermMatch(term, true,
+                          term.subSequence(stateForPrefix.index + 1, term.length()))), pos, pos + 1,
+                      true));
+                  // TODO: continue with next match after prefix match
+                }
+              }
+            }
+          }
+
+        }
+
+        prefixes = newPrefixes;
+        newPrefixes = new LinkedList<>();
+
+        if (anyTermAtPosition) {
+          pos++;
+        }
+      }
+
+    }
+
+    return result;
+  }
+
+  @Override
+  public Set<Instruction> getInstructions() {
+
+    final Set<Instruction> result = new HashSet<Instruction>();
+
+    for (List<Properties> propertiesList : trieMap) {
+      for (Properties properties : propertiesList) {
+        result.addAll(properties.getInstructions());
+      }
+    }
+
+    return result;
+  }
+
+
+  public static class Prefix<T> {
+
+    final State<T> stateInfo;
+    final List<TermMatch> matches;
+
+    public Prefix(final Prefix<T> prefix, final TermMatch match, final State<T> stateInfo) {
+      matches = new LinkedList<>(prefix.matches);
+      addTerm(match);
+      this.stateInfo = stateInfo;
+    }
+
+    public Prefix(final Prefix<T> prefix, final State<T> stateInfo) {
+      matches = new LinkedList<>(prefix.matches);
+      this.stateInfo = stateInfo;
+    }
+
+    public Prefix(final TermMatch match, final State<T> stateInfo) {
+      matches = new LinkedList<>();
+      matches.add(match);
+      this.stateInfo = stateInfo;
+    }
+
+    public Prefix(final State<T> stateInfo) {
+      matches = new LinkedList<>();
+      this.stateInfo = stateInfo;
+    }
+
+
+    private void addTerm(final TermMatch term) {
+      matches.add(term);
+    }
+
+  }
+
+}

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/model/TrieMapRulesPropertiesCollectionBuilder.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/model/TrieMapRulesPropertiesCollectionBuilder.java
@@ -3,26 +3,26 @@
  */
 package querqy.rewrite.commonrules.model;
 
-import java.util.LinkedList;
-import java.util.List;
-
 import querqy.ComparableCharSequence;
 import querqy.CompoundCharSequence;
 import querqy.trie.State;
 import querqy.trie.States;
 import querqy.trie.TrieMap;
 
+import java.util.LinkedList;
+import java.util.List;
+
 /**
  * @author René Kriegler, @renekrie
  *
  */
-public class TrieMapRulesCollectionBuilder implements RulesCollectionBuilder {
+public class TrieMapRulesPropertiesCollectionBuilder implements RulesCollectionBuilder {
     
-    final TrieMap<List<Instructions>> map = new TrieMap<>();
+    final TrieMap<List<Properties>> map = new TrieMap<>();
     
     final boolean ignoreCase;
     
-    public TrieMapRulesCollectionBuilder(boolean ignoreCase) {
+    public TrieMapRulesPropertiesCollectionBuilder(boolean ignoreCase) {
         this.ignoreCase = ignoreCase;
     }
 
@@ -30,9 +30,8 @@ public class TrieMapRulesCollectionBuilder implements RulesCollectionBuilder {
      * @see querqy.rewrite.commonrules.model.RulesCollectionBuilder#addRule(querqy.rewrite.commonrules.model.Input, querqy.rewrite.commonrules.model.Instructions)
      */
     @Override
-    public void addRule(Input input,  Properties properties) {
-
-        Instructions instructions = properties.getInstructions();
+    public void addRule(Input input, Properties properties) {
+        
         List<Term> inputTerms = input.getInputTerms();
         
         switch (inputTerms.size()) {
@@ -43,14 +42,14 @@ public class TrieMapRulesCollectionBuilder implements RulesCollectionBuilder {
             }
             
             ComparableCharSequence seq = new CompoundCharSequence(" ", TrieMapRulesCollection.BOUNDARY_WORD, TrieMapRulesCollection.BOUNDARY_WORD);
-            States<List<Instructions>> states = map.get(seq);
-            State<List<Instructions>> state = states.getStateForCompleteSequence();
+            States<List<Properties>> states = map.get(seq);
+            State<List<Properties>> state = states.getStateForCompleteSequence();
             if (state.value != null) {
-                state.value.add(instructions);
+                state.value.add(properties);
             } else {
-                List<Instructions> instructionsList = new LinkedList<>();
-                instructionsList.add(instructions);
-                map.put(seq, instructionsList);
+                List<Properties> propertiesList = new LinkedList<>();
+                propertiesList.add(properties);
+                map.put(seq, propertiesList);
             }
             
         }
@@ -66,17 +65,17 @@ public class TrieMapRulesCollectionBuilder implements RulesCollectionBuilder {
                 
                 seq = applyBoundaries(seq, input.requiresLeftBoundary, input.requiresRightBoundary);
                 
-                States<List<Instructions>> states = map.get(seq);
+                States<List<Properties>> states = map.get(seq);
                 
                 if (isPrefix) {
                     boolean added = false;
                     
-                    List<State<List<Instructions>>> prefixes = states.getPrefixes();
+                    List<State<List<Properties>>> prefixes = states.getPrefixes();
                     
                     if (prefixes != null) {
-                        for (State<List<Instructions>> state: prefixes) {
+                        for (State<List<Properties>> state: prefixes) {
                             if (state.isFinal() && state.index == (seq.length() - 1) && state.value != null) {
-                                state.value.add(instructions);
+                                state.value.add(properties);
                                 added = true;
                                 break;
                             }
@@ -85,19 +84,19 @@ public class TrieMapRulesCollectionBuilder implements RulesCollectionBuilder {
                     }
                     
                     if (!added) {
-                        List<Instructions> instructionsList = new LinkedList<>();
-                        instructionsList.add(instructions);
-                        map.putPrefix(seq, instructionsList);
+                        List<Properties> propertiesList = new LinkedList<>();
+                        propertiesList.add(properties);
+                        map.putPrefix(seq, propertiesList);
                     }
                 
                 } else {
-                    State<List<Instructions>> state = states.getStateForCompleteSequence();
+                    State<List<Properties>> state = states.getStateForCompleteSequence();
                     if (state.value != null) {
-                        state.value.add(instructions);
+                        state.value.add(properties);
                     } else {
-                        List<Instructions> instructionsList = new LinkedList<>();
-                        instructionsList.add(instructions);
-                        map.put(seq, instructionsList);
+                        List<Properties> propertiesList = new LinkedList<>();
+                        propertiesList.add(properties);
+                        map.put(seq, propertiesList);
                     }
                     
                 }
@@ -112,18 +111,18 @@ public class TrieMapRulesCollectionBuilder implements RulesCollectionBuilder {
                 
                 seq = applyBoundaries(seq, input.requiresLeftBoundary, input.requiresRightBoundary);
                 
-                States<List<Instructions>> states = map.get(seq);
+                States<List<Properties>> states = map.get(seq);
                 
                 if (isPrefix) { 
                     
                     boolean added = false;
                     
-                    List<State<List<Instructions>>> prefixes = states.getPrefixes();
+                    List<State<List<Properties>>> prefixes = states.getPrefixes();
                     
                     if (prefixes != null) {
-                        for (State<List<Instructions>> state: prefixes) {
+                        for (State<List<Properties>> state: prefixes) {
                             if (state.isFinal() && state.index == (seq.length() - 1) && state.value != null) {
-                                state.value.add(instructions);
+                                state.value.add(properties);
                                 added = true;
                                 break;
                             }
@@ -132,18 +131,18 @@ public class TrieMapRulesCollectionBuilder implements RulesCollectionBuilder {
                     }
                     
                     if (!added) {
-                        List<Instructions> instructionsList = new LinkedList<>();
-                        instructionsList.add(instructions);
-                        map.putPrefix(seq, instructionsList);
+                        List<Properties> propertiesList = new LinkedList<>();
+                        propertiesList.add(properties);
+                        map.putPrefix(seq, propertiesList);
                     }
                 } else {
-                    State<List<Instructions>> state = states.getStateForCompleteSequence();
+                    State<List<Properties>> state = states.getStateForCompleteSequence();
                     if (state.value != null) {
-                        state.value.add(instructions);
+                        state.value.add(properties);
                     } else {
-                        List<Instructions> instructionsList = new LinkedList<>();
-                        instructionsList.add(instructions);
-                        map.put(seq, instructionsList);
+                        List<Properties> propertiesList = new LinkedList<>();
+                        propertiesList.add(properties);
+                        map.put(seq, propertiesList);
                     }
                 }
                 
@@ -172,7 +171,7 @@ public class TrieMapRulesCollectionBuilder implements RulesCollectionBuilder {
      */
     @Override
     public RulesCollection build() {
-        return new TrieMapRulesCollection(map, ignoreCase);
+        return new TrieMapRulesPropertiesCollection(map, ignoreCase);
     }
 
 }

--- a/querqy-core/src/test/java/querqy/rewrite/commonrules/SimpleParserTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/commonrules/SimpleParserTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import org.junit.After;
 import org.junit.Test;
 
+import querqy.Constants;
 import querqy.model.Clause.Occur;
 import querqy.model.InputSequenceElement;
 import querqy.model.Query;
@@ -39,12 +40,12 @@ public class SimpleParserTest extends AbstractCommonRulesTest {
     
     SimpleCommonRulesParser createParserWithEmptyReader() {
         reader = new StringReader("");
-        return new SimpleCommonRulesParser(reader, querqyParserFactory, false);
+        return new SimpleCommonRulesParser(reader, querqyParserFactory, false, Constants.DEFAULT_RULES_MAP);
     }
     
     SimpleCommonRulesParser createParserFromResource(String resourceName, boolean ignoreCase) {
         reader = new InputStreamReader(getClass().getClassLoader().getResourceAsStream(resourceName));
-        return new SimpleCommonRulesParser(reader, querqyParserFactory, ignoreCase);
+        return new SimpleCommonRulesParser(reader, querqyParserFactory, ignoreCase,  Constants.DEFAULT_RULES_MAP);
     }
     
     RulesCollection createRulesFromResource(String resourceName, boolean ignoreCase) throws IOException, RuleParseException {

--- a/querqy-core/src/test/java/querqy/rewrite/commonrules/model/BoostInstructionTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/commonrules/model/BoostInstructionTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 
+import querqy.Constants;
 import querqy.model.BoostQuery;
 import querqy.model.ExpandedQuery;
 import querqy.model.QuerqyQuery;
@@ -35,10 +36,10 @@ public class BoostInstructionTest extends AbstractCommonRulesTest {
         RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
         
         BoostInstruction boostInstruction = new BoostInstruction(makeQuery("a").getUserQuery(), BoostDirection.UP, 0.5f);
-        builder.addRule(new Input(Arrays.asList(mkTerm("x")), false, false), new Instructions(Arrays.asList((Instruction) boostInstruction)));
+        builder.addRule(new Input(Arrays.asList(mkTerm("x")), false, false), new Properties(new Instructions(Arrays.asList((Instruction) boostInstruction))));
 
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("x");
         Collection<BoostQuery> upQueries = rewriter.rewrite(query, EMPTY_CONTEXT).getBoostUpQueries();
@@ -63,10 +64,10 @@ public class BoostInstructionTest extends AbstractCommonRulesTest {
         RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
 
         BoostInstruction boostInstruction = new BoostInstruction(makeQuery("a b").getUserQuery(), BoostDirection.UP, 0.5f);
-        builder.addRule(new Input(Arrays.asList(mkTerm("x")), false, false), new Instructions(Arrays.asList((Instruction) boostInstruction)));
+        builder.addRule(new Input(Arrays.asList(mkTerm("x")), false, false), new Properties(new Instructions(Arrays.asList((Instruction) boostInstruction))));
 
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("x");
         Collection<BoostQuery> upQueries = rewriter.rewrite(query, EMPTY_CONTEXT).getBoostUpQueries();
@@ -92,10 +93,10 @@ public class BoostInstructionTest extends AbstractCommonRulesTest {
         RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
 
         BoostInstruction boostInstruction = new BoostInstruction(makeQuery("a +b").getUserQuery(), BoostDirection.UP, 0.5f);
-        builder.addRule(new Input(Arrays.asList(mkTerm("x")), false, false), new Instructions(Arrays.asList((Instruction) boostInstruction)));
+        builder.addRule(new Input(Arrays.asList(mkTerm("x")), false, false), new Properties(new Instructions(Arrays.asList((Instruction) boostInstruction))));
 
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("x");
         Collection<BoostQuery> upQueries = rewriter.rewrite(query, EMPTY_CONTEXT).getBoostUpQueries();
@@ -121,10 +122,10 @@ public class BoostInstructionTest extends AbstractCommonRulesTest {
         RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
 
         BoostInstruction boostInstruction = new BoostInstruction(makeQuery("-a b").getUserQuery(), BoostDirection.UP, 0.5f);
-        builder.addRule(new Input(Arrays.asList(mkTerm("x")), false, false), new Instructions(Arrays.asList((Instruction) boostInstruction)));
+        builder.addRule(new Input(Arrays.asList(mkTerm("x")), false, false), new Properties(new Instructions(Arrays.asList((Instruction) boostInstruction))));
 
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("x");
         Collection<BoostQuery> upQueries = rewriter.rewrite(query, EMPTY_CONTEXT).getBoostUpQueries();
@@ -149,10 +150,10 @@ public class BoostInstructionTest extends AbstractCommonRulesTest {
         RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
 
         BoostInstruction boostInstruction = new BoostInstruction(makeQuery("-a b").getUserQuery(), BoostDirection.UP, 0.5f);
-        builder.addRule(new Input(Arrays.asList(mkTerm("x")), false, false), new Instructions(Arrays.asList((Instruction) boostInstruction)));
+        builder.addRule(new Input(Arrays.asList(mkTerm("x")), false, false), new Properties(new Instructions(Arrays.asList((Instruction) boostInstruction))));
 
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("x");
         QuerqyQuery<?> mainQuery = rewriter.rewrite(query, EMPTY_CONTEXT).getUserQuery();
@@ -166,10 +167,10 @@ public class BoostInstructionTest extends AbstractCommonRulesTest {
         RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
 
         BoostInstruction boostInstruction = new BoostInstruction(makeQuery("a b").getUserQuery(), BoostDirection.UP, 0.5f);
-        builder.addRule(new Input(Arrays.asList(mkTerm("x")), false, false), new Instructions(Arrays.asList((Instruction) boostInstruction)));
+        builder.addRule(new Input(Arrays.asList(mkTerm("x")), false, false), new Properties(new Instructions(Arrays.asList((Instruction) boostInstruction))));
 
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("x");
         Collection<BoostQuery> upQueries = rewriter.rewrite(query, EMPTY_CONTEXT).getBoostUpQueries();
@@ -185,11 +186,11 @@ public class BoostInstructionTest extends AbstractCommonRulesTest {
 
         BoostInstruction boostInstruction = new BoostInstruction(makeQuery("a b$1").getUserQuery(), BoostDirection.DOWN, 0.2f);
 
-        builder.addRule((Input) LineParser.parseInput("x k*"), new Instructions(Collections.singletonList((Instruction) boostInstruction)));
+        builder.addRule((Input) LineParser.parseInput("x k*"), new Properties(new Instructions(Collections.singletonList((Instruction) boostInstruction))));
 
 
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
 
         ExpandedQuery query = makeQuery("x klm y");
@@ -211,11 +212,11 @@ public class BoostInstructionTest extends AbstractCommonRulesTest {
 
         BoostInstruction boostInstruction = new BoostInstruction(makeQuery("a b$1").getUserQuery(), BoostDirection.DOWN, 0.2f);
 
-        builder.addRule((Input) LineParser.parseInput("x k*"), new Instructions(Collections.singletonList((Instruction) boostInstruction)));
+        builder.addRule((Input) LineParser.parseInput("x k*"), new Properties(new Instructions(Collections.singletonList((Instruction) boostInstruction))));
 
 
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
 
         ExpandedQuery query = makeQuery("x klm y");
@@ -250,11 +251,11 @@ public class BoostInstructionTest extends AbstractCommonRulesTest {
 
         BoostInstruction boostInstruction = new BoostInstruction(makeQuery("a $1").getUserQuery(), BoostDirection.DOWN, 0.3f);
 
-        builder.addRule((Input) LineParser.parseInput("x k*"), new Instructions(Collections.singletonList((Instruction) boostInstruction)));
+        builder.addRule((Input) LineParser.parseInput("x k*"), new Properties(new Instructions(Collections.singletonList((Instruction) boostInstruction))));
 
 
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
 
         ExpandedQuery query = makeQuery("x klm y");
@@ -288,11 +289,11 @@ public class BoostInstructionTest extends AbstractCommonRulesTest {
 
         BoostInstruction boostInstruction = new BoostInstruction(makeQuery("a c$1d").getUserQuery(), BoostDirection.UP, 0.3f);
 
-        builder.addRule((Input) LineParser.parseInput("k*"), new Instructions(Collections.singletonList((Instruction) boostInstruction)));
+        builder.addRule((Input) LineParser.parseInput("k*"), new Properties(new Instructions(Collections.singletonList((Instruction) boostInstruction))));
 
 
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
 
         ExpandedQuery query = makeQuery("x klm y");

--- a/querqy-core/src/test/java/querqy/rewrite/commonrules/model/CommonRulesRewriterTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/commonrules/model/CommonRulesRewriterTest.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import querqy.Constants;
 import querqy.model.ExpandedQuery;
 import querqy.model.Query;
 import querqy.rewrite.commonrules.AbstractCommonRulesTest;
@@ -26,9 +27,9 @@ public class CommonRulesRewriterTest extends AbstractCommonRulesTest {
     public void testInputBoundaryOnBothSides() {
         RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
         SynonymInstruction synInstruction = new SynonymInstruction(Arrays.asList(mkTerm("s1")));
-        builder.addRule(new Input(Arrays.asList(mkTerm("a")), true, true), new Instructions(Arrays.asList((Instruction) synInstruction)));
+        builder.addRule(new Input(Arrays.asList(mkTerm("a")), true, true), new Properties(new Instructions(Arrays.asList((Instruction) synInstruction))));
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("a");
         Query rewritten = (Query) rewriter.rewrite(query, EMPTY_CONTEXT).getUserQuery();
@@ -102,9 +103,9 @@ public class CommonRulesRewriterTest extends AbstractCommonRulesTest {
     public void testInputBoundaryOnLeftHandSide() {
         RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
         SynonymInstruction synInstruction = new SynonymInstruction(Arrays.asList(mkTerm("s1")));
-        builder.addRule(new Input(Arrays.asList(mkTerm("a")), true, false), new Instructions(Arrays.asList((Instruction) synInstruction)));
+        builder.addRule(new Input(Arrays.asList(mkTerm("a")), true, false), new Properties(new Instructions(Arrays.asList((Instruction) synInstruction))));
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("a");
         Query rewritten = (Query) rewriter.rewrite(query, EMPTY_CONTEXT).getUserQuery();
@@ -176,9 +177,9 @@ public class CommonRulesRewriterTest extends AbstractCommonRulesTest {
     public void testInputBoundaryOnRightHandSide() {
         RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
         SynonymInstruction synInstruction = new SynonymInstruction(Arrays.asList(mkTerm("s1")));
-        builder.addRule(new Input(Arrays.asList(mkTerm("a")), false, true), new Instructions(Arrays.asList((Instruction) synInstruction)));
+        builder.addRule(new Input(Arrays.asList(mkTerm("a")), false, true), new Properties(new Instructions(Arrays.asList((Instruction) synInstruction))));
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("a");
         Query rewritten = (Query) rewriter.rewrite(query, EMPTY_CONTEXT).getUserQuery();
@@ -251,10 +252,10 @@ public class CommonRulesRewriterTest extends AbstractCommonRulesTest {
         RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
         SynonymInstruction synInstructionA = new SynonymInstruction(Arrays.asList(mkTerm("aSynonym")));
         SynonymInstruction synInstructionB = new SynonymInstruction(Arrays.asList(mkTerm("bSynonym")));
-        builder.addRule(new Input(Arrays.asList(mkTerm("a")), true, false), new Instructions(Arrays.asList((Instruction) synInstructionA)));
-        builder.addRule(new Input(Arrays.asList(mkTerm("b")), true, false), new Instructions(Arrays.asList((Instruction) synInstructionB)));
+        builder.addRule(new Input(Arrays.asList(mkTerm("a")), true, false), new Properties(new Instructions(Arrays.asList((Instruction) synInstructionA))));
+        builder.addRule(new Input(Arrays.asList(mkTerm("b")), true, false), new Properties(new Instructions(Arrays.asList((Instruction) synInstructionB))));
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("a b");
         Map<String, Object> context = new HashMap<>();

--- a/querqy-core/src/test/java/querqy/rewrite/commonrules/model/DecorateInstructionTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/commonrules/model/DecorateInstructionTest.java
@@ -12,6 +12,7 @@ import java.util.Set;
 
 import org.junit.Test;
 
+import querqy.Constants;
 import querqy.model.ExpandedQuery;
 import querqy.rewrite.commonrules.AbstractCommonRulesTest;
 import querqy.rewrite.commonrules.CommonRulesRewriter;
@@ -26,10 +27,10 @@ public class DecorateInstructionTest extends AbstractCommonRulesTest {
         RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
         DecorateInstruction deco = new DecorateInstruction("deco1");
         
-        builder.addRule(new Input(Arrays.asList(mkTerm("x")), false, false), new Instructions(Arrays.asList((Instruction) deco)));
+        builder.addRule(new Input(Arrays.asList(mkTerm("x")), false, false), new Properties(new Instructions(Arrays.asList((Instruction) deco))));
 
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("a x");
         Map<String, Object> context = new HashMap<>();
@@ -50,10 +51,10 @@ public class DecorateInstructionTest extends AbstractCommonRulesTest {
         RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
         DecorateInstruction deco = new DecorateInstruction("deco1");
         builder.addRule((Input) LineParser.parseInput(LineParser.BOUNDARY + "" + LineParser.BOUNDARY),
-                    new Instructions(Arrays.asList((Instruction) deco)));
+                new Properties(new Instructions(Arrays.asList((Instruction) deco))));
         
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("");
         Map<String, Object> context = new HashMap<>();
@@ -77,11 +78,11 @@ public class DecorateInstructionTest extends AbstractCommonRulesTest {
         DecorateInstruction deco2 = new DecorateInstruction("deco2");
         DecorateInstruction deco3 = new DecorateInstruction("deco3");
         
-        builder.addRule(new Input(Arrays.asList(mkTerm("x")), false, false), new Instructions(Arrays.asList((Instruction) deco1, (Instruction) deco2)));
-        builder.addRule(new Input(Arrays.asList(mkTerm("a")), false, false), new Instructions(Arrays.asList((Instruction) deco3)));
+        builder.addRule(new Input(Arrays.asList(mkTerm("x")), false, false),  new Properties(new Instructions(Arrays.asList((Instruction) deco1, (Instruction) deco2))));
+        builder.addRule(new Input(Arrays.asList(mkTerm("a")), false, false), new Properties(new Instructions(Arrays.asList((Instruction) deco3))));
 
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("a x");
         Map<String, Object> context = new HashMap<>();

--- a/querqy-core/src/test/java/querqy/rewrite/commonrules/model/DeleteInstructionTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/commonrules/model/DeleteInstructionTest.java
@@ -1,28 +1,19 @@
 package querqy.rewrite.commonrules.model;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.equalTo;
-import static querqy.QuerqyMatchers.*;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
-
 import org.junit.Test;
-
-import querqy.model.BoostQuery;
+import querqy.Constants;
 import querqy.model.DisjunctionMaxQuery;
 import querqy.model.ExpandedQuery;
 import querqy.model.Query;
 import querqy.rewrite.commonrules.AbstractCommonRulesTest;
 import querqy.rewrite.commonrules.CommonRulesRewriter;
 import querqy.rewrite.commonrules.LineParser;
-import querqy.rewrite.commonrules.model.DeleteInstruction;
-import querqy.rewrite.commonrules.model.Input;
-import querqy.rewrite.commonrules.model.Instruction;
-import querqy.rewrite.commonrules.model.Instructions;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static querqy.QuerqyMatchers.*;
 
 public class DeleteInstructionTest extends AbstractCommonRulesTest {
     
@@ -31,9 +22,9 @@ public class DeleteInstructionTest extends AbstractCommonRulesTest {
 
       RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
       DeleteInstruction delete = new DeleteInstruction(Arrays.asList(mkTerm("a")));
-      builder.addRule(new Input(Arrays.asList(mkTerm("a")), false, false), new Instructions(Arrays.asList((Instruction) delete)));
+      builder.addRule(new Input(Arrays.asList(mkTerm("a")), false, false), new Properties(new Instructions(Arrays.asList((Instruction) delete))));
       RulesCollection rules = builder.build();
-      CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+      CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
       ExpandedQuery query = makeQuery("a");
       Query rewritten = (Query) rewriter.rewrite(query, EMPTY_CONTEXT).getUserQuery();
@@ -51,9 +42,9 @@ public class DeleteInstructionTest extends AbstractCommonRulesTest {
    public void testThatTermIsRemovedIfThereIsAnotherTermInTheSameDMQ() throws Exception {
       RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
       DeleteInstruction delete = new DeleteInstruction(Arrays.asList(mkTerm("a")));
-      builder.addRule(new Input(Arrays.asList(mkTerm("a")), false, false), new Instructions(Arrays.asList((Instruction) delete)));
+      builder.addRule(new Input(Arrays.asList(mkTerm("a")), false, false), new Properties(new Instructions(Arrays.asList((Instruction) delete))));
       RulesCollection rules = builder.build();
-      CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+      CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
       ExpandedQuery expandedQuery = makeQuery("a");
       Query query = (Query) expandedQuery.getUserQuery();
@@ -76,9 +67,9 @@ public class DeleteInstructionTest extends AbstractCommonRulesTest {
    public void testThatTermIsRemovedOnceIfItExistsTwiceInSameDMQAndNoOtherTermExistsInQuery() throws Exception {
       RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
       DeleteInstruction delete = new DeleteInstruction(Arrays.asList(mkTerm("a")));
-      builder.addRule(new Input(Arrays.asList(mkTerm("a")), false, false), new Instructions(Arrays.asList((Instruction) delete)));
+      builder.addRule(new Input(Arrays.asList(mkTerm("a")), false, false), new Properties(new Instructions(Arrays.asList((Instruction) delete))));
       RulesCollection rules = builder.build();
-      CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+      CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
       ExpandedQuery expandedQuery = makeQuery("a");
       Query query = (Query) expandedQuery.getUserQuery();
@@ -102,9 +93,9 @@ public class DeleteInstructionTest extends AbstractCommonRulesTest {
    public void testThatTermIsRemovedIfThereASecondDMQWithoutTheTerm() throws Exception {
       RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
       DeleteInstruction delete = new DeleteInstruction(Arrays.asList(mkTerm("a")));
-      builder.addRule(new Input(Arrays.asList(mkTerm("a")), false, false), new Instructions(Arrays.asList((Instruction) delete)));
+      builder.addRule(new Input(Arrays.asList(mkTerm("a")), false, false), new Properties(new Instructions(Arrays.asList((Instruction) delete))));
       RulesCollection rules = builder.build();
-      CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+      CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
       Query rewritten = (Query) rewriter.rewrite(makeQuery("a b"), EMPTY_CONTEXT).getUserQuery();
 
@@ -120,9 +111,9 @@ public class DeleteInstructionTest extends AbstractCommonRulesTest {
    public void testThatTermIsNotRemovedOnceIfThereASecondDMQWithTheSameTermAndNoOtherTermExists() throws Exception {
       RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
       DeleteInstruction delete = new DeleteInstruction(Arrays.asList(mkTerm("a")));
-      builder.addRule(new Input(Arrays.asList(mkTerm("a")), false, false), new Instructions(Arrays.asList((Instruction) delete)));
+      builder.addRule(new Input(Arrays.asList(mkTerm("a")), false, false), new Properties(new Instructions(Arrays.asList((Instruction) delete))));
       RulesCollection rules = builder.build();
-      CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+      CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
       Query rewritten = (Query) rewriter.rewrite(makeQuery("a a"), EMPTY_CONTEXT).getUserQuery();
 
@@ -144,11 +135,11 @@ public class DeleteInstructionTest extends AbstractCommonRulesTest {
 
        DeleteInstruction deleteInstruction = new DeleteInstruction(input.getInputTerms());
 
-       builder.addRule(input, new Instructions(Collections.singletonList((Instruction) deleteInstruction)));
+       builder.addRule(input, new Properties(new Instructions(Collections.singletonList((Instruction) deleteInstruction))));
 
 
        RulesCollection rules = builder.build();
-       CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+       CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
 
        ExpandedQuery query = makeQuery("x klm");
@@ -177,11 +168,11 @@ public class DeleteInstructionTest extends AbstractCommonRulesTest {
 
         DeleteInstruction deleteInstruction = new DeleteInstruction(input.getInputTerms());
 
-        builder.addRule(input, new Instructions(Collections.singletonList((Instruction) deleteInstruction)));
+        builder.addRule(input, new Properties(new Instructions(Collections.singletonList((Instruction) deleteInstruction))));
 
 
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
 
         ExpandedQuery query = makeQuery("x ab klm");
@@ -209,11 +200,11 @@ public class DeleteInstructionTest extends AbstractCommonRulesTest {
 
         DeleteInstruction deleteInstruction = new DeleteInstruction(input.getInputTerms());
 
-        builder.addRule(input, new Instructions(Collections.singletonList((Instruction) deleteInstruction)));
+        builder.addRule(input, new Properties(new Instructions(Collections.singletonList((Instruction) deleteInstruction))));
 
 
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
 
         ExpandedQuery query = makeQuery("klm");

--- a/querqy-core/src/test/java/querqy/rewrite/commonrules/model/FilterInstructionTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/commonrules/model/FilterInstructionTest.java
@@ -3,6 +3,7 @@ package querqy.rewrite.commonrules.model;
 import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
+import querqy.Constants;
 import querqy.model.*;
 import querqy.rewrite.commonrules.AbstractCommonRulesTest;
 import querqy.rewrite.commonrules.CommonRulesRewriter;
@@ -33,10 +34,10 @@ public class FilterInstructionTest  extends AbstractCommonRulesTest {
 
         FilterInstruction filterInstruction = new FilterInstruction(makeQuery("a b").getUserQuery());
 
-        builder.addRule(new Input(Arrays.asList(mkTerm("x")), false, false), new Instructions(Arrays.asList((Instruction) filterInstruction)));
+        builder.addRule(new Input(Arrays.asList(mkTerm("x")), false, false), new Properties(new Instructions((Arrays.asList((Instruction) filterInstruction)))));
 
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("x");
         Collection<QuerqyQuery<?>> filterQueries = rewriter.rewrite(query, EMPTY_CONTEXT).getFilterQueries();
@@ -63,11 +64,11 @@ public class FilterInstructionTest  extends AbstractCommonRulesTest {
         FilterInstruction filterInstruction = new FilterInstruction(makeQuery("-ab").getUserQuery());
 
         builder.addRule(new Input(Collections.singletonList(mkTerm("x")), false, false),
-                new Instructions(Collections.singletonList((Instruction) filterInstruction)));
+                new Properties(new Instructions((Collections.singletonList((Instruction) filterInstruction)))));
 
         RulesCollection rules = builder.build();
 
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("x");
 
@@ -98,10 +99,10 @@ public class FilterInstructionTest  extends AbstractCommonRulesTest {
 
         FilterInstruction filterInstruction = new FilterInstruction(makeQuery("a").getUserQuery());
 
-        builder.addRule(new Input(Arrays.asList(mkTerm("x")), false, false), new Instructions(Arrays.asList((Instruction) filterInstruction)));
+        builder.addRule(new Input(Arrays.asList(mkTerm("x")), false, false), new Properties(new Instructions((Arrays.asList((Instruction) filterInstruction)))));
 
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("x");
         Collection<QuerqyQuery<?>> filterQueries = rewriter.rewrite(query, EMPTY_CONTEXT).getFilterQueries();
@@ -125,10 +126,10 @@ public class FilterInstructionTest  extends AbstractCommonRulesTest {
 
         FilterInstruction filterInstruction = new FilterInstruction(makeQuery("a").getUserQuery());
 
-        builder.addRule(new Input(Arrays.asList(mkTerm("x")), false, false), new Instructions(Arrays.asList((Instruction) filterInstruction)));
+        builder.addRule(new Input(Arrays.asList(mkTerm("x")), false, false), new Properties(new Instructions((Arrays.asList((Instruction) filterInstruction)))));
 
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("x");
         QuerqyQuery<?> mainQuery = rewriter.rewrite(query, EMPTY_CONTEXT).getUserQuery();

--- a/querqy-core/src/test/java/querqy/rewrite/commonrules/model/RulesCollectionTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/commonrules/model/RulesCollectionTest.java
@@ -34,7 +34,7 @@ public class RulesCollectionTest {
       Input input = new Input(inputTerms(null, s1), false, false);
 
       Instructions instructions = instructions("instruction1");
-      builder.addRule(input, instructions);
+      builder.addRule(input, new Properties(instructions));
 
       RulesCollection rulesCollection = builder.build();
       PositionSequence<InputSequenceElement> sequence = new PositionSequence<>();
@@ -56,7 +56,7 @@ public class RulesCollectionTest {
       Input input = new Input(inputTerms(null, s1), false, false);
 
       Instructions instructions = instructions("instruction1", "instruction2");
-      builder.addRule(input, instructions);
+      builder.addRule(input, new Properties(instructions));
 
       RulesCollection rulesCollection = builder.build();
       PositionSequence<InputSequenceElement> sequence = new PositionSequence<>();
@@ -78,10 +78,10 @@ public class RulesCollectionTest {
       Input input = new Input(inputTerms(null, s1), false, false);
 
       Instructions instructions1 = instructions("instruction1");
-      builder.addRule(input, instructions1);
+      builder.addRule(input, new Properties(instructions1));
 
       Instructions instructions2 = instructions("instruction2");
-      builder.addRule(input, instructions2);
+      builder.addRule(input, new Properties(instructions2));
 
       RulesCollection rulesCollection = builder.build();
       PositionSequence<InputSequenceElement> sequence = new PositionSequence<>();
@@ -105,10 +105,10 @@ public class RulesCollectionTest {
       Input input2 = new Input(inputTerms(null, s2), false, false);
 
       Instructions instructions1 = instructions("instruction1");
-      builder.addRule(input1, instructions1);
+      builder.addRule(input1, new Properties(instructions1));
 
       Instructions instructions2 = instructions("instruction2");
-      builder.addRule(input2, instructions2);
+      builder.addRule(input2, new Properties(instructions2));
 
       // Input is just s1
       RulesCollection rulesCollection = builder.build();
@@ -152,10 +152,10 @@ public class RulesCollectionTest {
       Input input2 = new Input(inputTerms(null, s2, s3), false, false);
 
       Instructions instructions1 = instructions("instruction1");
-      builder.addRule(input1, instructions1);
+      builder.addRule(input1, new Properties(instructions1));
 
       Instructions instructions2 = instructions("instruction2");
-      builder.addRule(input2, instructions2);
+      builder.addRule(input2, new Properties(instructions2));
 
       // Input is just s1
       RulesCollection rulesCollection = builder.build();
@@ -202,8 +202,8 @@ public class RulesCollectionTest {
       Instructions instructions1 = instructions("instruction1");
       Instructions instructions2 = instructions("instruction2");
 
-      builder.addRule(input2, instructions2);
-      builder.addRule(input1, instructions1);
+      builder.addRule(input2, new Properties(instructions2));
+      builder.addRule(input1, new Properties(instructions1));
 
       // Input is s1 s2
       RulesCollection rulesCollection = builder.build();
@@ -236,10 +236,10 @@ public class RulesCollectionTest {
       Input input2 = new Input(inputTerms(null, s2), false, false);
 
       Instructions instructions1 = instructions("instruction1");
-      builder.addRule(input1, instructions1);
+      builder.addRule(input1, new Properties(instructions1));
 
       Instructions instructions2 = instructions("instruction2");
-      builder.addRule(input2, instructions2);
+      builder.addRule(input2, new Properties(instructions2));
 
       // Input is just s1
       RulesCollection rulesCollection = builder.build();
@@ -275,7 +275,7 @@ public class RulesCollectionTest {
                   ), false, false);
 
       Instructions instructions1 = instructions("instruction1");
-      builder.addRule(input1, instructions1);
+      builder.addRule(input1, new Properties(instructions1));
 
       Term term11 = new Term(null, "f11", s1);
       Term term12 = new Term(null, "f12", s1);

--- a/querqy-core/src/test/java/querqy/rewrite/commonrules/model/SynonymInstructionTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/commonrules/model/SynonymInstructionTest.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import querqy.Constants;
 import querqy.model.ExpandedQuery;
 import querqy.model.Query;
 import querqy.rewrite.commonrules.AbstractCommonRulesTest;
@@ -19,9 +20,9 @@ public class SynonymInstructionTest extends AbstractCommonRulesTest {
     public void testThatSingleTermIsExpandedWithSingleTerm() {
         RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
         SynonymInstruction synInstruction = new SynonymInstruction(Arrays.asList(mkTerm("s1")));
-        builder.addRule(new Input(Arrays.asList(mkTerm("a"))), new Instructions(Arrays.asList((Instruction) synInstruction)));
+        builder.addRule(new Input(Arrays.asList(mkTerm("a"))), new Properties(new Instructions(Arrays.asList((Instruction) synInstruction))));
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("a");
         Query rewritten = (Query) rewriter.rewrite(query, EMPTY_CONTEXT).getUserQuery();
@@ -43,11 +44,11 @@ public class SynonymInstructionTest extends AbstractCommonRulesTest {
         SynonymInstruction synInstruction1 = new SynonymInstruction(Arrays.asList(mkTerm("s1")));
         SynonymInstruction synInstruction2 = new SynonymInstruction(Arrays.asList(mkTerm("s2")));
         SynonymInstruction synInstruction3 = new SynonymInstruction(Arrays.asList(mkTerm("s3")));
-        builder.addRule(new Input(Arrays.asList(mkTerm("a"))), new Instructions(Arrays.asList((Instruction) synInstruction1)));
-        builder.addRule(new Input(Arrays.asList(mkTerm("b"))), new Instructions(Arrays.asList((Instruction) synInstruction2)));
-        builder.addRule(new Input(Arrays.asList(mkTerm("c"))), new Instructions(Arrays.asList((Instruction) synInstruction3)));
+        builder.addRule(new Input(Arrays.asList(mkTerm("a"))), new Properties(new Instructions(Arrays.asList((Instruction) synInstruction1))));
+        builder.addRule(new Input(Arrays.asList(mkTerm("b"))), new Properties(new Instructions(Arrays.asList((Instruction) synInstruction2))));
+        builder.addRule(new Input(Arrays.asList(mkTerm("c"))), new Properties(new Instructions(Arrays.asList((Instruction) synInstruction3))));
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("a b c");
         Query rewritten = (Query) rewriter.rewrite(query, EMPTY_CONTEXT).getUserQuery();
@@ -78,9 +79,9 @@ public class SynonymInstructionTest extends AbstractCommonRulesTest {
     public void testThatSingleTermIsExpandedByMany() throws Exception {
         RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
         SynonymInstruction synInstruction = new SynonymInstruction(Arrays.asList(mkTerm("s1_1"), mkTerm("s1_2")));
-        builder.addRule(new Input(Arrays.asList(mkTerm("a"))), new Instructions(Arrays.asList((Instruction) synInstruction)));
+        builder.addRule(new Input(Arrays.asList(mkTerm("a"))), new Properties(new Instructions(Arrays.asList((Instruction) synInstruction))));
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("a");
         Query rewritten = (Query) rewriter.rewrite(query, EMPTY_CONTEXT).getUserQuery();
@@ -102,9 +103,9 @@ public class SynonymInstructionTest extends AbstractCommonRulesTest {
     public void testThatMultipleTermsAreExpandedBySingle() throws Exception {
         RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
         SynonymInstruction synInstruction = new SynonymInstruction(Arrays.asList(mkTerm("s1")));
-        builder.addRule(new Input(Arrays.asList(mkTerm("a"), mkTerm("b"))), new Instructions(Arrays.asList((Instruction) synInstruction)));
+        builder.addRule(new Input(Arrays.asList(mkTerm("a"), mkTerm("b"))), new Properties(new Instructions(Arrays.asList((Instruction) synInstruction))));
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("a b");
         Query rewritten = (Query) rewriter.rewrite(query, EMPTY_CONTEXT).getUserQuery();
@@ -129,9 +130,9 @@ public class SynonymInstructionTest extends AbstractCommonRulesTest {
     public void testThatMultipleTermsAreExpandedByMany() throws Exception {
         RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
         SynonymInstruction synInstruction = new SynonymInstruction(Arrays.asList(mkTerm( "s1_1"), mkTerm("s1_2")));
-        builder.addRule(new Input(Arrays.asList(mkTerm("a"), mkTerm("b"))), new Instructions(Arrays.asList((Instruction) synInstruction)));
+        builder.addRule(new Input(Arrays.asList(mkTerm("a"), mkTerm("b"))), new Properties(new Instructions(Arrays.asList((Instruction) synInstruction))));
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("a b c");
         Query rewritten = (Query) rewriter.rewrite(query, EMPTY_CONTEXT).getUserQuery();
@@ -166,10 +167,10 @@ public class SynonymInstructionTest extends AbstractCommonRulesTest {
         
         RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
         SynonymInstruction synInstruction = new SynonymInstruction(Arrays.asList(mkTerm( "p1"), mkTerm("$1")));
-        builder.addRule((Input) LineParser.parseInput("p1*"), new Instructions(Arrays.asList((Instruction) synInstruction)));
+        builder.addRule((Input) LineParser.parseInput("p1*"), new Properties(new Instructions(Arrays.asList((Instruction) synInstruction))));
         
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("p1xyz");
         Query rewritten = (Query) rewriter.rewrite(query, EMPTY_CONTEXT).getUserQuery();
@@ -196,10 +197,10 @@ public class SynonymInstructionTest extends AbstractCommonRulesTest {
         
         RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
         SynonymInstruction synInstruction = new SynonymInstruction(Arrays.asList(mkTerm( "bus"), mkTerm("$1")));
-        builder.addRule((Input) LineParser.parseInput("bus*"), new Instructions(Arrays.asList((Instruction) synInstruction)));
+        builder.addRule((Input) LineParser.parseInput("bus*"), new Properties(new Instructions(Arrays.asList((Instruction) synInstruction))));
         
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("busstop");
         Query rewritten = (Query) rewriter.rewrite(query, EMPTY_CONTEXT).getUserQuery();
@@ -226,10 +227,10 @@ public class SynonymInstructionTest extends AbstractCommonRulesTest {
         
         RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
         SynonymInstruction synInstruction = new SynonymInstruction(Arrays.asList(mkTerm( "p2"), mkTerm("$1")));
-        builder.addRule((Input) LineParser.parseInput("p1 p2*"), new Instructions(Arrays.asList((Instruction) synInstruction)));
+        builder.addRule((Input) LineParser.parseInput("p1 p2*"), new Properties(new Instructions(Arrays.asList((Instruction) synInstruction))));
         
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("p1 p2xyz");
         Query rewritten = (Query) rewriter.rewrite(query, EMPTY_CONTEXT).getUserQuery();
@@ -265,10 +266,10 @@ public class SynonymInstructionTest extends AbstractCommonRulesTest {
         
         RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
         SynonymInstruction synInstruction = new SynonymInstruction(Arrays.asList(mkTerm( "p1"), mkTerm("$1")));
-        builder.addRule((Input) LineParser.parseInput("p1*"), new Instructions(Arrays.asList((Instruction) synInstruction)));
+        builder.addRule((Input) LineParser.parseInput("p1*"), new Properties(new Instructions(Arrays.asList((Instruction) synInstruction))));
         
         RulesCollection rules = builder.build();
-        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter rewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
 
         ExpandedQuery query = makeQuery("p1");
         Query rewritten = (Query) rewriter.rewrite(query, EMPTY_CONTEXT).getUserQuery();

--- a/querqy-core/src/test/java/querqy/rewrite/contrib/ShingleRewriteTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/contrib/ShingleRewriteTest.java
@@ -1,20 +1,16 @@
 package querqy.rewrite.contrib;
 
-import java.util.Arrays;
-
 import org.junit.Test;
-
+import querqy.Constants;
 import querqy.model.*;
+import querqy.model.Term;
 import querqy.rewrite.commonrules.AbstractCommonRulesTest;
 import querqy.rewrite.commonrules.CommonRulesRewriter;
 import querqy.rewrite.commonrules.LineParser;
-import querqy.rewrite.commonrules.model.Input;
-import querqy.rewrite.commonrules.model.Instruction;
-import querqy.rewrite.commonrules.model.Instructions;
-import querqy.rewrite.commonrules.model.RulesCollection;
-import querqy.rewrite.commonrules.model.RulesCollectionBuilder;
-import querqy.rewrite.commonrules.model.SynonymInstruction;
-import querqy.rewrite.commonrules.model.TrieMapRulesCollectionBuilder;
+import querqy.rewrite.commonrules.model.*;
+
+import java.util.Arrays;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static querqy.QuerqyMatchers.*;
 
@@ -251,10 +247,10 @@ public class ShingleRewriteTest extends AbstractCommonRulesTest {
     public void testChainingWithWildCard() throws Exception {
         RulesCollectionBuilder builder = new TrieMapRulesCollectionBuilder(false);
         SynonymInstruction synInstruction = new SynonymInstruction(Arrays.asList(mkTerm( "p1"), mkTerm("$1")));
-        builder.addRule((Input) LineParser.parseInput("p1*"), new Instructions(Arrays.asList((Instruction) synInstruction)));
+        builder.addRule((Input) LineParser.parseInput("p1*"), new Properties(new Instructions(Arrays.asList((Instruction) synInstruction))));
         
         RulesCollection rules = builder.build();
-        CommonRulesRewriter commonRulesRewriter = new CommonRulesRewriter(rules);
+        CommonRulesRewriter commonRulesRewriter = new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
         ShingleRewriter shingleRewriter = new ShingleRewriter(false);
 
         ExpandedQuery query = makeQuery("p1xyz t2");

--- a/querqy-for-lucene/pom.xml
+++ b/querqy-for-lucene/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <querqy.core.version>3.1.0</querqy.core.version>
+        <querqy.core.version>3.1.1-SNAPSHOT</querqy.core.version>
         <querqy.antlr.version>3.0.2</querqy.antlr.version>
         <lucene.version>7.2.0</lucene.version>
         <commons.io.version>2.5</commons.io.version>

--- a/querqy-for-lucene/querqy-solr/pom.xml
+++ b/querqy-for-lucene/querqy-solr/pom.xml
@@ -48,6 +48,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <!--
                 needed by solr-test-framework (with scope=provided, not scope=test)
              -->
@@ -96,6 +103,25 @@
                         <phase>package</phase>
                         <goals>
                             <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.9</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>generate-code-coverage-report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyQueryComponent.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyQueryComponent.java
@@ -44,7 +44,11 @@ public class QuerqyQueryComponent extends QueryComponent {
                     filters.addAll(filterQueries);
                 }
             }
-            
+            rb.addDebugInfo("Querqy Criterion", ((QuerqyDismaxQParser) parser).getQuerqyCriterion());
+            rb.addDebugInfo("Querqy Applied Rules",
+                    ((QuerqyDismaxQParser) parser).getQuerqyAppliedRules());
+
+
         }
     }
 

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/SimpleCommonRulesRewriterFactory.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/SimpleCommonRulesRewriterFactory.java
@@ -9,6 +9,7 @@ import java.io.InputStreamReader;
 import org.apache.lucene.analysis.util.ResourceLoader;
 import org.apache.solr.common.util.NamedList;
 
+import querqy.Constants;
 import querqy.rewrite.RewriterFactory;
 import querqy.rewrite.commonrules.QuerqyParserFactory;
 import querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory;
@@ -34,6 +35,16 @@ public class SimpleCommonRulesRewriterFactory implements RewriterFactoryAdapter 
             throw new IllegalArgumentException("Property 'rules' not configured");
         }
 
+        String rulesMapType = (String) args.get(Constants.RULES_MAP_TYPE);
+        if(rulesMapType == null) {
+            rulesMapType = Constants.DEFAULT_RULES_MAP;
+        }
+
+        String ruleSelectionStratedgy = (String) args.get(Constants.SELECTION_STRATEDGY);
+        if(ruleSelectionStratedgy == null) {
+            ruleSelectionStratedgy = Constants.DEFAULT_SELECTION_STRATEDGY;
+        }
+
         final Boolean ignoreCase = args.getBooleanArg("ignoreCase");
 
         // querqy parser for queries that are part of the instructions in the
@@ -54,7 +65,7 @@ public class SimpleCommonRulesRewriterFactory implements RewriterFactoryAdapter 
         return new querqy.rewrite.commonrules.SimpleCommonRulesRewriterFactory(
                 new InputStreamReader(resourceLoader.openResource(rulesResourceName), "UTF-8"),
                 querqyParser,
-                ignoreCase == null || ignoreCase);
+                ignoreCase == null || ignoreCase, rulesMapType, ruleSelectionStratedgy);
     }
 
 }

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/SynonymFormatCommonRulesRewriterFactory.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/SynonymFormatCommonRulesRewriterFactory.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import org.apache.lucene.analysis.util.ResourceLoader;
 import org.apache.solr.common.util.NamedList;
 
+import querqy.Constants;
 import querqy.model.Clause.Occur;
 import querqy.model.DisjunctionMaxQuery;
 import querqy.model.ExpandedQuery;
@@ -24,14 +25,8 @@ import querqy.model.Term;
 import querqy.rewrite.QueryRewriter;
 import querqy.rewrite.RewriterFactory;
 import querqy.rewrite.commonrules.CommonRulesRewriter;
-import querqy.rewrite.commonrules.model.BoostInstruction;
+import querqy.rewrite.commonrules.model.*;
 import querqy.rewrite.commonrules.model.BoostInstruction.BoostDirection;
-import querqy.rewrite.commonrules.model.Input;
-import querqy.rewrite.commonrules.model.Instruction;
-import querqy.rewrite.commonrules.model.Instructions;
-import querqy.rewrite.commonrules.model.RulesCollection;
-import querqy.rewrite.commonrules.model.RulesCollectionBuilder;
-import querqy.rewrite.commonrules.model.TrieMapRulesCollectionBuilder;
 
 /**
  * @author René Kriegler, @renekrie
@@ -115,7 +110,7 @@ public class SynonymFormatCommonRulesRewriterFactory implements
                                  if (!query.getClauses().isEmpty()) {
                                     for (Input input : inputs) {
                                        BoostInstruction bi = new BoostInstruction(query, direction, boost);
-                                       builder.addRule(input, new Instructions(Collections.singletonList((Instruction) bi)));
+                                       builder.addRule(input,  buildProperty( new Instructions(Collections.singletonList((Instruction) bi))));
                                     }
                                  }
                               }
@@ -191,7 +186,7 @@ public class SynonymFormatCommonRulesRewriterFactory implements
       @Override
       public QueryRewriter createRewriter(ExpandedQuery input,
             Map<String, ?> context) {
-         return new CommonRulesRewriter(rules);
+          return new CommonRulesRewriter(rules, Constants.DEFAULT_SELECTION_STRATEDGY);
       }
 
     @Override
@@ -204,5 +199,10 @@ public class SynonymFormatCommonRulesRewriterFactory implements
     }
 
    }
+
+   private static Properties buildProperty(Instructions instructions) {
+      return new Properties(instructions);
+   }
+
 
 }

--- a/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/DefaultQuerqyDismaxQParserWithCommonRulesTest.java
+++ b/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/DefaultQuerqyDismaxQParserWithCommonRulesTest.java
@@ -345,7 +345,8 @@ public class DefaultQuerqyDismaxQParserWithCommonRulesTest extends SolrTestCaseJ
     public void testSolrResponseContainsDebugInformationOfRulesRewriter() throws Exception {
         String q = "a b";
 
-        String debugQueryRuleForA = "Action [instructions=[[FilterInstruction [filterQuery=RawQuery [queryString=f2:c]]]], " +
+        String debugQueryRuleForA = "Action [properties=[Properties(instructions=[FilterInstruction " +
+                "[filterQuery=RawQuery [queryString=f2:c]]], propertyMap=null)], " +
                 "terms=[TermMatch{queryTerm=*:a, isPrefix=false, wildcardMatch=null}], startPosition=0, endPosition=1]";
 
         SolrQueryRequest requestWithDebugQueryEnabled = req("q", q,


### PR DESCRIPTION
Currently if for 1 search term, there can be cases for multiple rules get selected and getting applied.
So in the updated part, User can choose which rules can be applied, by adding filtering, sorting and selection criteria.
For ex: for a search term "black shoes" , there can be multiple rules .
In that case user can provide the criteria in URL to solr as:

    Sorting criteria: "rules.criteria.sort": "priority desc"
    multiple Filter criteria: "rules.criteria.filter": "active:true"
    Selection criteria i.e after applying filter & sorting there can be multiple rules, so if user wants to apply top n rules, they can mention that as "rules.criteria.size": "1",
    
