### PR TITLE
Declare missing <version> for some of the Maven plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,10 +18,56 @@
         <maven>3.3.0</maven>
     </prerequisites>
 
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>1.8</java.version>
+        <junit.version>4.12</junit.version>
+        <hamcrest.version>2.1</hamcrest.version>
+        <mockito.version>2.27.0</mockito.version>
+        <slf4j.version>1.7.26</slf4j.version>
+
+        <maven-assembly-plugin.version>3.1.1</maven-assembly-plugin.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
+        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+        <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
+    </properties>
+
     <modules>
         <module>querqy-core</module>
         <module>querqy-antlr</module>
         <module>querqy-for-lucene</module>
     </modules>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest</artifactId>
+                <version>${hamcrest.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.hamcrest</groupId>
+                        <artifactId>hamcrest-core</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/querqy-antlr/pom.xml
+++ b/querqy-antlr/pom.xml
@@ -2,6 +2,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>querqy</groupId>
+        <artifactId>querqy-parent</artifactId>
+        <version>3.2.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
     <groupId>querqy</groupId>
     <artifactId>querqy-antlr</artifactId>
     <version>3.0.3-SNAPSHOT</version>
@@ -12,16 +19,10 @@
         <tag>HEAD</tag>
     </scm>
 
-    <prerequisites>
-        <maven>3.2.0</maven>
-    </prerequisites>
-
     <properties>
         <querqy.core.version>3.0.2</querqy.core.version>
         <antlr4.visitor>true</antlr4.visitor>
-        <junit.version>4.11</junit.version>
-        <hamcrest.version>1.3</hamcrest.version>
-        <mockito.version>1.10.19</mockito.version>
+        <antlr4.version>4.2.2</antlr4.version>
     </properties>
 
     <repositories>
@@ -51,34 +52,22 @@
 
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <version>${hamcrest.version}</version>
-            <scope>test</scope>
+            <artifactId>hamcrest</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.hamcrest</groupId>
-                    <artifactId>hamcrest-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
         </dependency>
 
 
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
-            <version>4.2.2</version>
+            <version>${antlr4.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.abego.treelayout</groupId>
@@ -100,7 +89,7 @@
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
-                <version>4.2.2</version>
+                <version>${antlr4.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/querqy-core/pom.xml
+++ b/querqy-core/pom.xml
@@ -2,6 +2,13 @@
 
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>querqy</groupId>
+        <artifactId>querqy-parent</artifactId>
+        <version>3.2.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
     <artifactId>querqy-core</artifactId>
     <groupId>querqy</groupId>
     <version>3.3.0-SNAPSHOT</version>
@@ -13,41 +20,18 @@
         <tag>HEAD</tag>
     </scm>
 
-    <prerequisites>
-        <maven>3.2.0</maven>
-    </prerequisites>
-
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <junit.version>4.11</junit.version>
-        <hamcrest.version>1.3</hamcrest.version>
-        <mockito.version>1.10.19</mockito.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <version>${hamcrest.version}</version>
-            <scope>test</scope>
+            <artifactId>hamcrest</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.hamcrest</groupId>
-                    <artifactId>hamcrest-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -57,6 +41,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -69,6 +54,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven-jar-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -82,8 +68,9 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.3</version>
+                    <version>${maven-release-plugin.version}</version>
                     <configuration>
                         <useReleaseProfile>false</useReleaseProfile>
                         <releaseProfiles>release</releaseProfiles>
@@ -93,15 +80,16 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin.version}</version>
                     <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
                     </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>cobertura-maven-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>${cobertura-maven-plugin.version}</version>
                     <configuration>
                         <instrumentation>
                             <excludes>
@@ -126,7 +114,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.6</version>
+                <version>${cobertura-maven-plugin.version}</version>
             </plugin>
         </plugins>
     </reporting>

--- a/querqy-for-lucene/pom.xml
+++ b/querqy-for-lucene/pom.xml
@@ -1,6 +1,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>querqy</groupId>
+        <artifactId>querqy-parent</artifactId>
+        <version>3.2.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
     <groupId>querqy</groupId>
     <artifactId>querqy-for-lucene</artifactId>
     <version>4.4.lucene720.0-SNAPSHOT</version>
@@ -13,20 +20,11 @@
         <tag>HEAD</tag>
     </scm>
 
-    <prerequisites>
-        <maven>3.3.0</maven>
-    </prerequisites>
-
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <querqy.core.version>3.2.1</querqy.core.version>
         <querqy.antlr.version>3.0.2</querqy.antlr.version>
         <lucene.version>7.2.0</lucene.version>
         <commons.io.version>2.5</commons.io.version>
-        <slf4j.version>1.7.24</slf4j.version>
-        <junit.version>4.11</junit.version>
-        <hamcrest.version>1.3</hamcrest.version>
-        <mockito.version>1.10.19</mockito.version>
     </properties>
 
     <modules>
@@ -45,27 +43,15 @@
     <dependencies>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <version>${hamcrest.version}</version>
-            <scope>test</scope>
+            <artifactId>hamcrest</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.hamcrest</groupId>
-                    <artifactId>hamcrest-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -75,7 +61,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.20.1</version>
+                <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <systemPropertyVariables>
                         <tests.codec>Lucene70</tests.codec>
@@ -85,6 +71,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -98,8 +85,9 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.3</version>
+                    <version>${maven-release-plugin.version}</version>
                     <configuration>
                         <useReleaseProfile>false</useReleaseProfile>
                         <releaseProfiles>release</releaseProfiles>
@@ -107,17 +95,19 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin.version}</version>
                     <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
                         <showDeprecation>true</showDeprecation>
                     </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>cobertura-maven-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>${cobertura-maven-plugin.version}</version>
                     <configuration>
                         <instrumentation>
                             <excludes>
@@ -141,7 +131,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.6</version>
+                <version>${cobertura-maven-plugin.version}</version>
             </plugin>
         </plugins>
     </reporting>

--- a/querqy-for-lucene/querqy-lucene/pom.xml
+++ b/querqy-for-lucene/querqy-lucene/pom.xml
@@ -78,6 +78,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/contrib/rewrite/WordBreakCompoundRewriterTest.java
+++ b/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/contrib/rewrite/WordBreakCompoundRewriterTest.java
@@ -1,9 +1,9 @@
 package querqy.lucene.contrib.rewrite;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static querqy.QuerqyMatchers.bq;
@@ -19,7 +19,7 @@ import org.apache.lucene.search.spell.WordBreakSpellChecker;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import querqy.model.Clause;
 import querqy.model.DisjunctionMaxQuery;
@@ -101,8 +101,8 @@ public class WordBreakCompoundRewriterTest {
 
     @Test
     public void testThatGeneratedTermIsNotSplit() throws IOException {
-        when(wordBreakSpellChecker.suggestWordBreaks(any(), anyInt(), any(), any(), any()))
-                .thenReturn(new SuggestWord[][] { decompoundSuggestion("w1", "w2") });
+//        when(wordBreakSpellChecker.suggestWordBreaks(any(), anyInt(), any(), any(), any()))
+//                .thenReturn(new SuggestWord[][] { decompoundSuggestion("w1", "w2") });
 
         WordBreakCompoundRewriter rewriter = new WordBreakCompoundRewriter(wordBreakSpellChecker, indexReader, "field1",
                 false, false, new TrieMap<>(), 5, false);
@@ -131,8 +131,8 @@ public class WordBreakCompoundRewriterTest {
                 .thenReturn(new SuggestWord[][] {new SuggestWord[] {}});
 
         // compound of terms at idx 0+1
-        when(wordBreakSpellChecker.suggestWordCombinations(any(), anyInt(), any(), any()))
-                .thenReturn(new  CombineSuggestion[] { combineSuggestion("w1w2", 0, 1) });
+//        when(wordBreakSpellChecker.suggestWordCombinations(any(), anyInt(), any(), any()))
+//                .thenReturn(new  CombineSuggestion[] { combineSuggestion("w1w2", 0, 1) });
 
 
         WordBreakCompoundRewriter rewriter = new WordBreakCompoundRewriter(wordBreakSpellChecker, indexReader, "field1",
@@ -167,8 +167,8 @@ public class WordBreakCompoundRewriterTest {
                 .thenReturn(new SuggestWord[][] {new SuggestWord[] {}});
 
         // compound of terms at idx 0+1
-        when(wordBreakSpellChecker.suggestWordCombinations(any(), anyInt(), any(), any()))
-                .thenReturn(new  CombineSuggestion[] { combineSuggestion("w1w2", 0, 1) });
+//        when(wordBreakSpellChecker.suggestWordCombinations(any(), anyInt(), any(), any()))
+//                .thenReturn(new  CombineSuggestion[] { combineSuggestion("w1w2", 0, 1) });
 
 
         WordBreakCompoundRewriter rewriter = new WordBreakCompoundRewriter(wordBreakSpellChecker, indexReader, "field1",

--- a/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/rewrite/TermSubQueryBuilderTest.java
+++ b/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/rewrite/TermSubQueryBuilderTest.java
@@ -1,7 +1,7 @@
 package querqy.lucene.rewrite;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/rewrite/prms/PRMSAndQueryTest.java
+++ b/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/rewrite/prms/PRMSAndQueryTest.java
@@ -28,7 +28,7 @@ import querqy.lucene.rewrite.*;
 import querqy.lucene.rewrite.SearchFieldsAndBoosting.FieldBoostModel;
 import querqy.parser.WhiteSpaceQuerqyParser;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 
 public class PRMSAndQueryTest extends LuceneTestCase {
 

--- a/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/rewrite/prms/PRMSDisjunctionMaxQueryTest.java
+++ b/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/rewrite/prms/PRMSDisjunctionMaxQueryTest.java
@@ -29,7 +29,7 @@ import querqy.lucene.rewrite.SearchFieldsAndBoosting.FieldBoostModel;
 
 import querqy.parser.WhiteSpaceQuerqyParser;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 
 public class PRMSDisjunctionMaxQueryTest extends LuceneTestCase {
 

--- a/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/rewrite/prms/PRMSFieldBoostTest.java
+++ b/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/rewrite/prms/PRMSFieldBoostTest.java
@@ -28,7 +28,7 @@ import querqy.lucene.rewrite.*;
 import querqy.lucene.rewrite.SearchFieldsAndBoosting.FieldBoostModel;
 import querqy.parser.WhiteSpaceQuerqyParser;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 
 public class PRMSFieldBoostTest extends LuceneTestCase {
 

--- a/querqy-for-lucene/querqy-solr/pom.xml
+++ b/querqy-for-lucene/querqy-solr/pom.xml
@@ -72,6 +72,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -83,9 +84,9 @@
             </plugin>
 
             <plugin>
-
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-
+                <version>${maven-assembly-plugin.version}</version>
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>

--- a/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/AbstractQuerqyDismaxQParserPluginTest.java
+++ b/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/AbstractQuerqyDismaxQParserPluginTest.java
@@ -1,7 +1,7 @@
 package querqy.solr;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/QuerqyDismaxQParserTest.java
+++ b/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/QuerqyDismaxQParserTest.java
@@ -1,6 +1,6 @@
 package querqy.solr;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
@@ -12,14 +12,13 @@ import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.search.ExtendedQuery;
-import org.apache.solr.search.SyntaxError;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
+
 import querqy.lucene.LuceneQueries;
-import querqy.lucene.LuceneSearchEngineRequestAdapter;
 import querqy.model.ExpandedQuery;
 import querqy.model.MatchAllQuery;
 import querqy.parser.QuerqyParser;
@@ -133,7 +132,7 @@ public class QuerqyDismaxQParserTest {
 
         when(request.getSchema()).thenReturn(schema);
         when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
-        when(rewriteChain.rewrite(any(), any())).thenReturn(new ExpandedQuery(new MatchAllQuery()));
+//        when(rewriteChain.rewrite(any(), any())).thenReturn(new ExpandedQuery(new MatchAllQuery()));
 
         final ModifiableSolrParams solrParams = new ModifiableSolrParams();
         solrParams.add("qf", "f1");


### PR DESCRIPTION
Extract <properties> for the versions of dependencies and plugins.
Update the versions of testing libraries (JUnit 4.x, Hamcrest and Mockito)
Comment out some Mockito stubs which were claimed as not needed by Mockito 2.x. I didn't remove them completely so that the author can decide whether a better solution can be applied, e.g. extend the tests to use the stubbs.